### PR TITLE
Add Note for Escaping $ in Traefik Basic Auth Passwords

### DIFF
--- a/.env
+++ b/.env
@@ -6,6 +6,8 @@ TRAEFIK_HOSTNAME=traefik.keycloak.heyvaldemar.net
 # Basic Authentication for Traefik Dashboard
 # Username: traefikadmin
 # Passwords must be encoded using MD5, SHA1, or BCrypt https://hostingcanada.org/htpasswd-generator/
+# Note: When setting TRAEFIK_BASIC_AUTH, ensure to double the '$' in your hash to avoid variable interpolation by Docker Compose. 
+# For instance, change $ to $$ within your password hash.
 TRAEFIK_BASIC_AUTH=traefikadmin:$$2y$$10$$sMzJfirKC75x/hVpiINeZOiSm.Jkity9cn4KwNkRvO7hSQVFc5FLO
 
 # Keycloak Variables


### PR DESCRIPTION
Hi!
TLDR:
This minor update adds a note to the **.env** file, clarifying the need to escape "$" characters in the **TRAEFIK_BASIC_AUTH** variable to prevent Docker Compose from interpreting them as variable references. This clarification aids in avoiding configuration errors when setting up basic auth for Traefik.

First of all, thank you for your guide. It was really helpful to me!
I'm new to Docker, and while using your guide, I encountered an error that prevented me from logging into Traefik:
`WARN[0000] The "qot3jd6x" variable is not set. Defaulting to a blank string.`
I spent some time trying to fix this issue, and the solution turned out to be simple. 
When generating a password using [https://hostingcanada.org/htpasswd-generator/](https://hostingcanada.org/htpasswd-generator/), it generates a hash like this: 
`admin:$apr1$pyi4617h$tCwtuS23T0.9pdLwkrEuZ0` 
I copy-pasted it into the .env file but forgot to double the "$" to prevent Docker from interpreting parts of the password as references to other variables. So, maybe a small note as a reminder could save some time for newbies like me by preventing an hour of searching for the error in the configuration :)