### PR TITLE
chore: add community health files + Dependabot grouping + docker ecosystem

### DIFF
--- a/.github/FUNDING.yml
+++ b/.github/FUNDING.yml
@@ -1,4 +1,0 @@
-github: heyvaldemar
-patreon: heyvaldemar
-ko_fi: heyvaldemar
-custom: ['paypal.com/paypalme/heyValdemarCOM', 'buymeacoffee.com/heyValdemar', 'ko-fi.com/heyValdemar']

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,11 +1,27 @@
-# To get started with Dependabot version updates, you'll need to specify which
-# package ecosystems to update and where the package manifests are located.
-# Please see the documentation for all configuration options:
 # https://docs.github.com/github/administering-a-repository/configuration-options-for-dependency-updates
 
 version: 2
 updates:
-  - package-ecosystem: "github-actions" # See documentation for possible values
-    directory: "/" # Location of package manifests
+  - package-ecosystem: "github-actions"
+    directory: "/"
     schedule:
       interval: "weekly"
+    groups:
+      actions-minor-patch:
+        patterns:
+          - "*"
+        update-types:
+          - "minor"
+          - "patch"
+
+  - package-ecosystem: "docker"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    groups:
+      docker-minor-patch:
+        patterns:
+          - "*"
+        update-types:
+          - "minor"
+          - "patch"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,32 @@
+# Changelog
+
+All notable changes to this project are documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+### Added
+- `LICENSE` — canonical MIT license text at repo root, `Copyright (c) 2021-2026 Vladimir Mikhalev (heyvaldemar)`.
+- `SECURITY.md` — vulnerability disclosure policy, supported versions, supply-chain trust statement, and a callout for the pre-PR-#12 credential rotation advisory.
+- `CHANGELOG.md` — this file, Keep-a-Changelog format.
+
+### Changed
+- Dependabot gained a `docker` ecosystem to track upstream image digest bumps weekly, alongside the existing `github-actions` ecosystem. Both ecosystems now group minor/patch bumps into a single PR per week; major bumps continue to open individual PRs.
+
+### Removed
+- `.github/FUNDING.yml` — sponsor discovery moves to heyvaldemar.com. Aligns with the same decision applied across other heyvaldemar public repositories.
+
+### Security
+- Credentials untracked from `.env` in PR #12 (merged 2026-04-23). `.env.example` now ships `change_me_*` placeholders and the docker-compose `${VAR:?}` syntax fails fast if required variables are unset.
+
+## Project history prior to this changelog
+
+Earlier commits did not follow Keep-a-Changelog. Highlights:
+
+- **2021 (initial commit):** Keycloak + PostgreSQL + Traefik with Let's Encrypt deployment template.
+- **2021–2025:** iterative updates to image tags (Traefik 1.x → 3.x, Keycloak 15.x → 26.x, PostgreSQL), healthcheck hardening, backup container with pruning.
+- **2026-04:** alignment with the supply-chain hardening track established by [heyvaldemar/aws-kubectl-docker](https://github.com/heyvaldemar/aws-kubectl-docker).
+
+[Unreleased]: https://github.com/heyvaldemar/keycloak-traefik-letsencrypt-docker-compose/commits/main

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2021-2026 Vladimir Mikhalev (heyvaldemar)
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,38 @@
+# Security Policy
+
+## Supported Versions
+
+| Version                                          | Status             |
+|--------------------------------------------------|--------------------|
+| Current `main` + tagged semver releases          | :white_check_mark: |
+| Older tags / branches without a recent rebuild   | :x:                |
+
+A formal release / maintenance-branch split will be introduced once this repo is tagged for the first semver release.
+
+## Reporting a Vulnerability
+
+Send reports to **v@valdemar.ai**. Encrypted email is preferred — the PGP public key is published at [heyvaldemar.com/security](https://heyvaldemar.com/security).
+
+You can expect an acknowledgment within **7 days**. This project does not operate a bounty program; researchers who submit valid, responsibly disclosed reports receive public credit in the release notes and the changelog.
+
+Please do not open public GitHub issues for security reports.
+
+## Supply Chain Trust
+
+This repository publishes a **deployment template**, not a custom Docker image. It orchestrates well-known upstream images:
+
+- [`traefik`](https://hub.docker.com/_/traefik) — reverse proxy, official image
+- [`quay.io/keycloak/keycloak`](https://quay.io/repository/keycloak/keycloak) — Keycloak upstream
+- [`postgres`](https://hub.docker.com/_/postgres) — PostgreSQL, official image
+
+Upstream image tags are pinned to specific versions and will migrate to immutable `@sha256:...` digests in an upcoming PR. Dependabot's `docker` ecosystem tracks digest bumps weekly.
+
+## Known historical issue
+
+Prior to PR #12 (merged 2026-04-23), `.env` committed real values for three credentials:
+
+- `KEYCLOAK_DB_PASSWORD`
+- `KEYCLOAK_ADMIN_PASSWORD`
+- `TRAEFIK_BASIC_AUTH` (BCrypt hash)
+
+Those values remain in git history but are no longer referenced by any live file. Anyone who deployed with the pre-rotation configuration should rotate their live credentials and regenerate the Traefik dashboard BCrypt hash. See PR #12 for details and the `.env.example` for the rotation procedure.


### PR DESCRIPTION
## Summary

Scaffolding PR — lands community-health files, Dependabot groups, and the `docker` ecosystem that upcoming workflow hardening and README rewrite PRs will depend on. **No runtime behaviour change** from `main` post-PR-#12.

This is PR 2 of the series aligning this repo's standards with [`aws-kubectl-docker`](https://github.com/heyvaldemar/aws-kubectl-docker). It's also the **template-making PR** — the files landing here (LICENSE shape, SECURITY.md structure, CHANGELOG format, Dependabot config) are intentionally designed to be 1:1 reusable on the maintainer's 30+ other `-traefik-letsencrypt-docker-compose` repositories.

## What changed per file

- **`LICENSE`** (new, 1093 bytes) — canonical MIT license text, `Copyright (c) 2021-2026 Vladimir Mikhalev (heyvaldemar)`. First commit was in 2021 (verified via `git log --reverse`). Repo was claimed MIT in practice; no file existed until now. Unblocks GitHub's license detection and downstream license-scanning tooling.

- **`SECURITY.md`** (new) — follows the `aws-kubectl-docker` shape with three sections:
  1. Supported Versions table (`main` + tagged semver supported; older tags not).
  2. Reporting a Vulnerability — contact `v@valdemar.ai`, 7-day ack, public credit, no bounty.
  3. **Supply Chain Trust** — specific to deployment-template repos, this section names the upstream images (`traefik`, `quay.io/keycloak/keycloak`, `postgres`) and points at the upcoming digest-pin PR.
  4. Historical issue callout for PR #12 credential rotation.

- **`CHANGELOG.md`** (new) — Keep-a-Changelog format. `[Unreleased]` documents this PR plus PR #12 (security fix). A short "Project history prior to this changelog" appendix covers 2021-2025 so the file is honest about when the project actually started.

- **`.github/dependabot.yml`** — two ecosystems, both grouped:
  - `github-actions` (existing) gained `groups: actions-minor-patch` — minor/patch bumps now land as one PR per week, majors continue to open individual PRs.
  - **New: `docker` ecosystem** with identical `docker-minor-patch` group. Once upstream image digests are pinned in the compose file (upcoming PR), Dependabot auto-opens weekly bump PRs for `traefik`, `keycloak`, and `postgres` base images.

- **`.github/FUNDING.yml`** — **deleted**. Sponsor discovery moves to heyvaldemar.com. Same alignment decision already applied to `aws-kubectl-docker` and `quake3-server-docker-compose`.

## Verification (local)

- [x] `python3 -c "import yaml; yaml.safe_load(open('.github/dependabot.yml'))"` parses.
- [x] `wc -c LICENSE` → 1093 bytes (canonical MIT is ~1070).
- [x] `grep -c "^## " CHANGELOG.md` → 2 (`[Unreleased]` + `Project history prior to this changelog`).
- [x] `.github/FUNDING.yml` gone.
- [x] No runtime change — compose file, workflow, `.env.example`, `.gitignore`, README, script untouched.

## Test plan (post-merge)

- [ ] GitHub's license detection picks up MIT on the repo About sidebar.
- [ ] GitHub's Security tab surfaces the new `SECURITY.md` at the top of the page.
- [ ] "Sponsor" button no longer appears near the top of the repo page.
- [ ] Existing `00-deployment-verification.yml` workflow still runs green on this branch's PR check (no workflow change in this PR; sanity check only).
- [ ] Dependabot's next weekly run produces two grouped PRs (one for `github-actions`, one for `docker`) instead of one per action/image.

## Template-reuse notes

The files created here are intentionally designed to be copied onto other heyvaldemar `-traefik-letsencrypt-docker-compose` repos with minimal adaptation:

- **`LICENSE`** — change copyright year range to match that repo's first commit (`git log --reverse --format=%ai | head -1 | cut -d- -f1`).
- **`SECURITY.md`** — update the Supply Chain Trust section with the repo-specific upstream images, drop the PR-#12 historical-issue paragraph on repos without a prior credential leak.
- **`CHANGELOG.md`** — update the `[Unreleased]` link and the "Project history" paragraph per-repo; the `### Added/Changed/Removed` content transfers verbatim.
- **`.github/dependabot.yml`** — identical across all deployment-template repos; no adaptation needed.
- **`FUNDING.yml` deletion** — identical across all; no adaptation.

A consolidated `REPO_POLISH_RUNBOOK.md` with exact commands and find/replace blocks will follow after the full 6-PR series completes on this repo.

## What's next

- **PR 3** — Workflow hardening: pin every GitHub Action to a commit SHA with `# vX.Y.Z` comment, add per-job permissions, `timeout-minutes`, `concurrency` group, rename `00-deployment-verification.yml` → `deployment-verification.yml`, add weekly cron to catch upstream image drift.
- **PR 4** — Upstream image digest pinning: pin `postgres:16`, `traefik:3.2`, `quay.io/keycloak/keycloak:26.2.5` to `@sha256:...` digests. Dependabot's new `docker` ecosystem tracks weekly bumps automatically.
- **PR 5** — Full README rewrite in evaluator-first structure (badges, TOC, Why this, Getting started, Pinning guidance, Production checklist, Supply chain trust, Security Notes, unified About footer).
- **PR 6** — OpenSSF Scorecard workflow + badge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
