### PR TITLE
ci: pin SHAs + per-job permissions + timeouts + concurrency + weekly rebuild

### DIFF
--- a/.github/workflows/deployment-verification.yml
+++ b/.github/workflows/deployment-verification.yml
@@ -7,10 +7,26 @@ on:
   pull_request:
     branches:
       - main
+  schedule:
+    # Weekly rebuild to catch upstream image drift (new Traefik, Keycloak,
+    # or Postgres patch releases that break deployment).
+    - cron: "0 6 * * 1"
+  workflow_dispatch:
+
+concurrency:
+  group: deployment-verification-${{ github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
+permissions:
+  contents: read
 
 jobs:
   deploy-and-test:
+    name: docker compose up + HTTPS + Traefik dashboard smoke
     runs-on: ubuntu-latest
+    timeout-minutes: 15
+    permissions:
+      contents: read
 
     env:
       NETWORK_ONE: keycloak-network
@@ -22,12 +38,12 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
       - name: Create necessary Docker networks
         run: |
-          docker network create $NETWORK_ONE || true
-          docker network create $NETWORK_TWO || true
+          docker network create "$NETWORK_ONE" || true
+          docker network create "$NETWORK_TWO" || true
 
       - name: Generate test .env with ephemeral credentials
         # The real .env is gitignored. CI generates throwaway credentials so
@@ -56,7 +72,7 @@ jobs:
           echo "Generated ephemeral .env for CI run"
 
       - name: Start up services using Docker Compose
-        run: docker compose -f $DOCKER_COMPOSE_FILE -p $COMPOSE_PROJECT_NAME up -d
+        run: docker compose -f "$DOCKER_COMPOSE_FILE" -p "$COMPOSE_PROJECT_NAME" up -d
 
       - name: Modify /etc/hosts for internal routing
         run: |
@@ -69,28 +85,28 @@ jobs:
       - name: Wait for the application to be ready via Traefik
         run: |
           echo "Checking the routing and availability of the application via Traefik..."
-          timeout 5m bash -c 'while ! curl -fsSLk "https://$APP_HOSTNAME"; do \
-            echo "Waiting for the application to be ready..."; \
-            sleep 10; \
+          timeout 5m bash -c 'while ! curl -fsSLk "https://$APP_HOSTNAME"; do
+            echo "Waiting for the application to be ready..."
+            sleep 10
           done'
 
       - name: Wait for the Traefik dashboard to be ready
         run: |
           echo "Checking the routing and availability of the Traefik dashboard..."
-          timeout 5m bash -c 'while ! curl -fsSLk --write-out "%{http_code}" --output /dev/null "https://$APP_TRAEFIK_HOSTNAME" | grep -E "200|401"; do \
-            echo "Waiting for the application to be ready..."; \
-            sleep 10; \
+          timeout 5m bash -c 'while ! curl -fsSLk --write-out "%{http_code}" --output /dev/null "https://$APP_TRAEFIK_HOSTNAME" | grep -E "200|401"; do
+            echo "Waiting for the application to be ready..."
+            sleep 10
           done'
 
       - name: Inspect Network Configuration
         run: |
-          docker network inspect $NETWORK_ONE
-          docker network inspect $NETWORK_TWO
+          docker network inspect "$NETWORK_ONE"
+          docker network inspect "$NETWORK_TWO"
 
       - name: Show container logs on failure
         if: failure()
-        run: docker compose -f $DOCKER_COMPOSE_FILE -p $COMPOSE_PROJECT_NAME logs
+        run: docker compose -f "$DOCKER_COMPOSE_FILE" -p "$COMPOSE_PROJECT_NAME" logs
 
       - name: Shutdown Docker Compose services
         if: always()
-        run: docker compose -f $DOCKER_COMPOSE_FILE -p $COMPOSE_PROJECT_NAME down
+        run: docker compose -f "$DOCKER_COMPOSE_FILE" -p "$COMPOSE_PROJECT_NAME" down

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Keycloak with Let's Encrypt Using Docker Compose
 
-[![Deployment Verification](https://github.com/heyvaldemar/keycloak-traefik-letsencrypt-docker-compose/actions/workflows/00-deployment-verification.yml/badge.svg)](https://github.com/heyvaldemar/keycloak-traefik-letsencrypt-docker-compose/actions)
+[![Deployment Verification](https://github.com/heyvaldemar/keycloak-traefik-letsencrypt-docker-compose/actions/workflows/deployment-verification.yml/badge.svg?branch=main)](https://github.com/heyvaldemar/keycloak-traefik-letsencrypt-docker-compose/actions/workflows/deployment-verification.yml)
 
 The badge displayed on my repository indicates the status of the deployment verification workflow as executed on the latest commit to the main branch.
 


### PR DESCRIPTION
## Summary

Brings the existing deployment verification workflow in line with the supply-chain hardening baseline established in [`aws-kubectl-docker`](https://github.com/heyvaldemar/aws-kubectl-docker). No change to deployment behaviour — the verification job still runs the same `docker compose up` stack with ephemeral CI credentials (generated in PR #12).

This is PR 3 of the `keycloak-traefik-letsencrypt-docker-compose` standards-alignment series. Upcoming: upstream image digest pinning (PR 4), full README rewrite (PR 5), OpenSSF Scorecard workflow + badge (PR 6).

## What changed per file

- **`.github/workflows/deployment-verification.yml`** — hardened (renamed from `00-deployment-verification.yml` via `git mv` so history is preserved):
  - **Pinned** `actions/checkout` to commit SHA `de0fac2e4500dabe0009e67214ff5f5447ce83dd` with `# v6` version comment. Tag references can silently move to a different commit; commit SHAs cannot.
  - Added workflow-level `permissions: contents: read` and an identical per-job scope. Default runner token is broader than needed for a read-only smoke test.
  - Added `timeout-minutes: 15` on the `deploy-and-test` job — realistic ceiling is ~8-10 minutes.
  - Added `concurrency` group keyed per-ref (`deployment-verification-${{ github.ref }}`); in-progress runs cancel only for pull requests so branch/tag builds always complete.
  - Added weekly cron trigger `0 6 * * 1` (Mondays 06:00 UTC). Weekly runs surface upstream image drift — a Traefik/Keycloak/Postgres patch that silently breaks this stack now shows up within a week instead of at the next user-triggered push.
  - Added `workflow_dispatch` trigger so the job can be run on demand from the Actions UI.
  - Shell hygiene: quoted env-var references (`"$NETWORK_ONE"`, `"$DOCKER_COMPOSE_FILE"`, etc.) and removed trailing-backslash artefacts in the timeout loops.

- **`README.md`** — the Deployment Verification badge URL updated to the new filename (`deployment-verification.yml`) and pinned to `?branch=main` so it reflects main-branch status specifically.

## What did NOT change

- Deployment logic is byte-identical: same networks, same compose command, same `/etc/hosts` override, same HTTP/HTTPS smoke checks, same `logs`-on-failure, same `down`-always cleanup.
- Ephemeral `.env` generation step from PR #12 is preserved verbatim.
- No new actions added; only the existing one got a proper SHA pin.

## Verification (local)

- [x] `python3 -c "import yaml; yaml.safe_load(...)"` parses the new workflow file cleanly.
- [x] `grep "uses:"` confirms the commit SHA pin: `actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6`.
- [x] `grep -E "timeout-minutes|permissions:|concurrency|cron:"` confirms all four hardening items present.
- [x] `git mv` preserves rename history (visible in `git diff --cached --stat` as rename with 71% similarity).

## Test plan (post-merge)

- [ ] Workflow appears under the new name in the Actions tab.
- [ ] First main-push run completes successfully — same as the old workflow.
- [ ] README badge renders and links to the new workflow URL.
- [ ] Next Monday's scheduled run fires automatically at 06:00 UTC.
- [ ] Manual `workflow_dispatch` run succeeds from the Actions UI.

## Template-reuse notes

For the other 30+ `-traefik-letsencrypt-docker-compose` repos, this workflow shape is transferable with three repo-specific edits:

1. `NETWORK_ONE`, `NETWORK_TWO` — matches the two networks the compose file expects.
2. `DOCKER_COMPOSE_FILE`, `APP_HOSTNAME`, `APP_TRAEFIK_HOSTNAME`, `COMPOSE_PROJECT_NAME` — specific to each service.
3. The `Generate test .env` heredoc — the env-var list is specific to each service's `.env.example`.

Everything else (pinned SHA, triggers, permissions, timeouts, concurrency, cron) is identical. The `REPO_POLISH_RUNBOOK.md` that follows this 6-PR series will capture the exact find/replace pattern.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
