### PR TITLE
feat(supply-chain): pin upstream images by sha256 digest (Dependabot auto-bumps)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -6,9 +6,10 @@
 # Traefik reverse proxy
 # ──────────────────────────────────────────────────────────────────────────────
 
-# Traefik image tag. Pin to a specific minor for reproducibility; Dependabot
-# bumps the digest weekly (see `docker` ecosystem in .github/dependabot.yml).
-TRAEFIK_IMAGE_TAG=traefik:3.2
+# Traefik image — pinned by tag + sha256 digest for reproducible deployments.
+# Dependabot's `docker` ecosystem (see .github/dependabot.yml) auto-opens a PR
+# weekly when the upstream digest for `traefik:3.2` changes.
+TRAEFIK_IMAGE_TAG=traefik:3.2@sha256:e561a37f8710d9cf41c78bdf421d822b2c0b48267ec0552e644565fb55466ea9
 
 # Log level: DEBUG, INFO, WARN, ERROR. Use WARN or ERROR in production.
 TRAEFIK_LOG_LEVEL=WARN
@@ -37,12 +38,14 @@ TRAEFIK_BASIC_AUTH=change_me_generate_with_htpasswd_and_replace_this_string
 # Keycloak
 # ──────────────────────────────────────────────────────────────────────────────
 
-# PostgreSQL image for Keycloak's backing database. Pin as above.
-KEYCLOAK_POSTGRES_IMAGE_TAG=postgres:16
+# PostgreSQL image — pinned by tag + sha256 digest. Same Dependabot auto-bump
+# as TRAEFIK_IMAGE_TAG above.
+KEYCLOAK_POSTGRES_IMAGE_TAG=postgres:16@sha256:71e27bf60b70bded003791b5573f8b808365613f341df20ffcf0c1ed7bc13ddf
 
-# Keycloak server image. Quay.io upstream; monitor quay.io/keycloak/keycloak
-# for new releases.
-KEYCLOAK_IMAGE_TAG=quay.io/keycloak/keycloak:26.2.5
+# Keycloak server image — pinned by tag + sha256 digest. Quay.io upstream;
+# monitor quay.io/keycloak/keycloak for new releases. Dependabot tracks this
+# via the `docker` ecosystem too.
+KEYCLOAK_IMAGE_TAG=quay.io/keycloak/keycloak:26.2.5@sha256:4883630ef9db14031cde3e60700c9a9a8eaf1b5c24db1589d6a2d43de38ba2a9
 
 # Database name, user, and password (PostgreSQL). User and db-name can stay
 # default; password MUST be rotated.

--- a/.github/workflows/deployment-verification.yml
+++ b/.github/workflows/deployment-verification.yml
@@ -50,13 +50,13 @@ jobs:
         # `docker compose up` succeeds without committing secrets to the repo.
         run: |
           cat > .env <<EOF
-          TRAEFIK_IMAGE_TAG=traefik:3.2
+          TRAEFIK_IMAGE_TAG=traefik:3.2@sha256:e561a37f8710d9cf41c78bdf421d822b2c0b48267ec0552e644565fb55466ea9
           TRAEFIK_LOG_LEVEL=WARN
           TRAEFIK_ACME_EMAIL=ci@example.com
           TRAEFIK_HOSTNAME=${APP_TRAEFIK_HOSTNAME}
           TRAEFIK_BASIC_AUTH=traefikadmin:\$\$2y\$\$10\$\$sMzJfirKC75x/hVpiINeZOiSm.Jkity9cn4KwNkRvO7hSQVFc5FLO
-          KEYCLOAK_POSTGRES_IMAGE_TAG=postgres:16
-          KEYCLOAK_IMAGE_TAG=quay.io/keycloak/keycloak:26.2.5
+          KEYCLOAK_POSTGRES_IMAGE_TAG=postgres:16@sha256:71e27bf60b70bded003791b5573f8b808365613f341df20ffcf0c1ed7bc13ddf
+          KEYCLOAK_IMAGE_TAG=quay.io/keycloak/keycloak:26.2.5@sha256:4883630ef9db14031cde3e60700c9a9a8eaf1b5c24db1589d6a2d43de38ba2a9
           KEYCLOAK_DB_NAME=keycloakdb
           KEYCLOAK_DB_USER=keycloakdbuser
           KEYCLOAK_DB_PASSWORD=$(openssl rand -base64 24 | tr -d '/+=' | head -c 32)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,23 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `CHANGELOG.md` — this file, Keep-a-Changelog format.
 
 ### Changed
+- Upstream images pinned by `sha256` digest in addition to tag in `.env.example`
+  and the CI ephemeral `.env`. Three images are pinned:
+  - `traefik:3.2@sha256:e561a37f…`
+  - `postgres:16@sha256:71e27bf6…`
+  - `quay.io/keycloak/keycloak:26.2.5@sha256:4883630e…`
+  Docker compose now pulls the exact digest; silent upstream repushes cannot
+  alter a given deployment. Dependabot's `docker` ecosystem (added in this
+  release) auto-opens weekly PRs when upstream digests change.
 - Dependabot gained a `docker` ecosystem to track upstream image digest bumps weekly, alongside the existing `github-actions` ecosystem. Both ecosystems now group minor/patch bumps into a single PR per week; major bumps continue to open individual PRs.
+- GitHub Actions pinned by commit SHA instead of floating `@vN` tag — currently
+  one action (`actions/checkout@de0fac2e…` # v6) in the deployment-verification
+  workflow. Dependabot's `github-actions` ecosystem keeps the pin fresh.
+- Deployment verification workflow hardened: explicit `permissions: contents: read`,
+  `timeout-minutes: 15`, `concurrency` group keyed per-ref, weekly cron
+  (`0 6 * * 1`) for upstream image drift detection, and `workflow_dispatch`
+  trigger for manual runs. Workflow file renamed `00-deployment-verification.yml`
+  → `deployment-verification.yml`.
 
 ### Removed
 - `.github/FUNDING.yml` — sponsor discovery moves to heyvaldemar.com. Aligns with the same decision applied across other heyvaldemar public repositories.


### PR DESCRIPTION
## Summary

Upgrades this deployment template from **pinned-by-tag** to **pinned-by-tag-plus-sha256-digest** for the three upstream images it orchestrates: `traefik`, `postgres`, `quay.io/keycloak/keycloak`. Makes deployments reproducibly byte-identical across time.

This is PR 4 of the `keycloak-traefik-letsencrypt-docker-compose` standards-alignment series. Upcoming: full README rewrite (PR 5), OpenSSF Scorecard workflow + badge (PR 6).

## Why pin by digest

A tag can be silently re-pushed to a different manifest. A digest cannot. Two users deploying this repo on different days currently get **whatever `traefik:3.2` happened to resolve to that day** — which in practice drifts as Traefik ships patch releases under the same minor tag. After this PR, they get the exact same image manifest regardless of when they deploy.

This is the same supply-chain pattern used on [`aws-kubectl-docker`](https://github.com/heyvaldemar/aws-kubectl-docker) (ubuntu base image is digest-pinned there).

Zero friction to stay current: Dependabot's `docker` ecosystem (added in PR #13) auto-opens a weekly PR when any of the three upstream digests changes. Review diff → merge → CI re-runs → done.

## Resolved digests

| Image | Tag | Digest | Registry |
|---|---|---|---|
| Traefik | `3.2` | `sha256:e561a37f8710d9cf41c78bdf421d822b2c0b48267ec0552e644565fb55466ea9` | Docker Hub (`library/traefik`) |
| PostgreSQL | `16` | `sha256:71e27bf60b70bded003791b5573f8b808365613f341df20ffcf0c1ed7bc13ddf` | Docker Hub (`library/postgres`) |
| Keycloak | `26.2.5` | `sha256:4883630ef9db14031cde3e60700c9a9a8eaf1b5c24db1589d6a2d43de38ba2a9` | Quay.io (`keycloak/keycloak`) |

All three are **manifest index digests** (not platform-specific), so multi-arch pulls continue to work on both amd64 and arm64 hosts.

## What changed per file

- **`.env.example`** — three lines:
  - `TRAEFIK_IMAGE_TAG=traefik:3.2` → `traefik:3.2@sha256:e561a37f…`
  - `KEYCLOAK_POSTGRES_IMAGE_TAG=postgres:16` → `postgres:16@sha256:71e27bf6…`
  - `KEYCLOAK_IMAGE_TAG=quay.io/keycloak/keycloak:26.2.5` → `…:26.2.5@sha256:4883630e…`
  - Inline comment above each variable updated to mention the Dependabot auto-bump.

- **`.github/workflows/deployment-verification.yml`** — the ephemeral `.env` heredoc the CI job generates now uses the same digest-pinned values. CI exercises the same image manifests that downstream users will pull.

- **`CHANGELOG.md`** — `[Unreleased] → Changed` documents the digest pin and also back-fills the CI hardening landed in PR #14 (which merged without a changelog entry; catching up here).

## What did NOT change

- **The compose file itself** — it already uses `${TRAEFIK_IMAGE_TAG}`, `${KEYCLOAK_POSTGRES_IMAGE_TAG}`, and `${KEYCLOAK_IMAGE_TAG}` references. The `@sha256:...` suffix flows through from `.env` automatically. This is why this PR is so small — the hard work was already in place from PRs #12-#14.

## Verification (local)

- [x] `python3 -c "import yaml; yaml.safe_load(...)"` parses compose + workflow + dependabot.
- [x] `docker compose --env-file <test.env> config` resolves each service with the full `image:tag@sha256:...` reference in the output.
- [x] `grep IMAGE_TAG= .env.example` — all three lines include `@sha256:...`.
- [x] `grep IMAGE_TAG= .github/workflows/deployment-verification.yml` — the CI heredoc matches.

## Test plan (post-merge)

- [ ] Weekly-rebuild workflow run (Monday 06:00 UTC) pulls images by digest successfully and continues smoke-testing the stack.
- [ ] Dependabot's next `docker` ecosystem PR proposes a bump to one or more of the three digests. Merge the first one that lands to confirm the flow end-to-end.
- [ ] Downstream users pulling fresh (`git pull && docker compose up -d`) get byte-identical images vs a user who pulled an hour earlier.

## Template-reuse notes

For each of the other 30+ `-traefik-letsencrypt-docker-compose` repos, this PR's pattern is transferable with minimum adaptation:

1. Resolve each upstream image's digest via the registry API. Docker Hub example:
   ```bash
   TOKEN=$(curl -sS "https://auth.docker.io/token?service=registry.docker.io&scope=repository:library/<image>:pull" | jq -r .token)
   curl -sS -I -H "Authorization: Bearer $TOKEN" -H "Accept: application/vnd.oci.image.index.v1+json" \
     "https://registry-1.docker.io/v2/library/<image>/manifests/<tag>" | grep -i '^docker-content-digest:'
   ```
2. Append `@sha256:...` to each `X_IMAGE_TAG=...` line in `.env.example`.
3. Mirror the same changes in the CI workflow's ephemeral-.env heredoc.
4. One CHANGELOG entry.

Roughly 15 minutes per repo once the pattern is fluent. The `REPO_POLISH_RUNBOOK.md` that follows this 6-PR series will contain the exact shell snippets.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
