### PR TITLE
feat(ci): add OpenSSF Scorecard workflow + README badge

### DIFF
--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -1,0 +1,62 @@
+name: OpenSSF Scorecard
+
+on:
+  branch_protection_rule:
+  schedule:
+    # Weekly on Tuesdays at 06:00 UTC — after the Monday 06:00 UTC deployment
+    # verification run (deployment-verification.yml). Keeps the Scorecard
+    # score in sync with any weekly change in pinned-dependency posture.
+    - cron: "0 6 * * 2"
+  push:
+    branches: [main]
+  workflow_dispatch:
+
+# Scorecard needs broad read access to score the repo; individual jobs
+# narrow this further for the steps that need write scopes.
+permissions: read-all
+
+jobs:
+  analysis:
+    name: Scorecard analysis
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    permissions:
+      # Needed for SARIF upload to the Security tab.
+      security-events: write
+      # Needed to publish results to the public OpenSSF API (scorecard.dev).
+      id-token: write
+      # Needed to read the repo state and workflow history.
+      contents: read
+      actions: read
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          persist-credentials: false
+
+      - name: Run Scorecard analysis
+        # Pinned to the commit SHA of v2.4.3 (not the tag-object SHA returned
+        # by GitHub's /git/refs/tags endpoint, which Scorecard's own
+        # imposter-commit check rejects). See aws-kubectl-docker PR #24 for
+        # the background.
+        uses: ossf/scorecard-action@4eaacf0543bb3f2c246792bd56e8cdeffafb205a # v2.4.3
+        with:
+          results_file: results.sarif
+          results_format: sarif
+          # Publish results to the public OpenSSF API so the README badge
+          # populates. No token needed for public repos; the workflow's OIDC
+          # token authenticates.
+          publish_results: true
+
+      - name: Upload Scorecard results as workflow artifact
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: SARIF file
+          path: results.sarif
+          retention-days: 5
+
+      - name: Upload SARIF to GitHub Security tab
+        uses: github/codeql-action/upload-sarif@95e58e9a2cdfd71adc6e0353d5c52f41a045d225 # v4.35.2
+        with:
+          sarif_file: results.sarif

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
+- `.github/workflows/scorecard.yml` — OpenSSF Scorecard analysis workflow.
+  Runs weekly on Tuesdays at 06:00 UTC (one day after the Monday deployment
+  verification run), on every push to `main`, and on branch-protection-rule
+  changes. Publishes results to the public OpenSSF API (scorecard.dev
+  viewer) and uploads SARIF to the GitHub Security tab. All action pins
+  are commit-SHA based, including the dereferenced commit SHA for the
+  annotated-tag `ossf/scorecard-action@v2.4.3` (plain `@v2.4.3` tag-object
+  SHA is rejected by Scorecard's imposter-commit verification).
+- README badge for OpenSSF Scorecard, placed between the Deployment
+  Verification and License badges.
 - `LICENSE` — canonical MIT license text at repo root, `Copyright (c) 2021-2026 Vladimir Mikhalev (heyvaldemar)`.
 - `SECURITY.md` — vulnerability disclosure policy, supported versions, supply-chain trust statement, and a callout for the pre-PR-#12 credential rotation advisory.
 - `CHANGELOG.md` — this file, Keep-a-Changelog format.

--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 # Keycloak + Traefik + Let's Encrypt — Docker Compose
 
 [![Deployment Verification](https://github.com/heyvaldemar/keycloak-traefik-letsencrypt-docker-compose/actions/workflows/deployment-verification.yml/badge.svg?branch=main)](https://github.com/heyvaldemar/keycloak-traefik-letsencrypt-docker-compose/actions/workflows/deployment-verification.yml)
+[![OpenSSF Scorecard](https://api.scorecard.dev/projects/github.com/heyvaldemar/keycloak-traefik-letsencrypt-docker-compose/badge)](https://scorecard.dev/viewer/?uri=github.com/heyvaldemar/keycloak-traefik-letsencrypt-docker-compose)
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
 
 ## Contents


### PR DESCRIPTION
## Summary

Adds OpenSSF Scorecard analysis to this repo — weekly automated scoring of supply-chain security posture, results published to the public `scorecard.dev` viewer, SARIF uploaded to the GitHub Security tab.

**This is the final PR of the 6-PR standards-alignment series.** After merge, this repo matches the supply-chain hardening baseline established in [`heyvaldemar/aws-kubectl-docker`](https://github.com/heyvaldemar/aws-kubectl-docker).

## The 6-PR arc (completed after this merges)

| PR | Phase | Scope |
|---|---|---|
| #12 | 0 — Security | `.env` hygiene, credential rotation, fail-fast compose |
| #13 | 1 — Community | `LICENSE`, `SECURITY.md`, `CHANGELOG.md`, Dependabot groups + `docker` ecosystem, delete `FUNDING.yml` |
| #14 | 2 — CI hardening | Pinned SHAs, per-job permissions, `timeout-minutes`, `concurrency`, weekly cron, filename rename |
| #15 | 3 — Supply chain | Upstream image digest pinning with Dependabot auto-bumps |
| #16 | 4 — Documentation | Full README rewrite in evaluator-first structure |
| **#17 (this)** | **5 — Scorecard** | **OpenSSF Scorecard workflow + badge** |

## What changed per file

- **`.github/workflows/scorecard.yml`** (new, 62 lines) — matches the shape used on `aws-kubectl-docker`:
  - Triggers: weekly cron (Tuesday 06:00 UTC — one day after the Monday deployment verification run); every push to `main`; branch-protection-rule changes; `workflow_dispatch`.
  - Permissions: `read-all` at workflow level (Scorecard needs broad read access to audit settings); job-level narrows to `security-events: write` (SARIF upload), `id-token: write` (OpenSSF API OIDC), `contents: read`, `actions: read`.
  - All four action pins are **commit-SHA based** with `# vX.Y.Z` comments:

    | Action | SHA | Version | Tag type |
    |---|---|---|---|
    | `actions/checkout` | `de0fac2e...` | v6 | lightweight |
    | `ossf/scorecard-action` | `4eaacf05...` | v2.4.3 | **annotated, dereferenced** |
    | `actions/upload-artifact` | `043fb46d...` | v7.0.1 | lightweight |
    | `github/codeql-action/upload-sarif` | `95e58e9a...` | v4.35.2 | **annotated, dereferenced** |

    The two annotated tags have their tag-object SHA dereferenced to a commit SHA. Using the tag-object SHA (which `gh api /git/refs/tags/vX.Y.Z` returns by default) triggers Scorecard's own imposter-commit check and fails publication. Background: `aws-kubectl-docker` [PR #24](https://github.com/heyvaldemar/aws-kubectl-docker/pull/24).

- **`README.md`** — one new line. OpenSSF Scorecard badge added between Deployment Verification and License. Badge URL: `https://api.scorecard.dev/projects/github.com/heyvaldemar/keycloak-traefik-letsencrypt-docker-compose/badge`. Target URL: `https://scorecard.dev/viewer/?uri=...`.

- **`CHANGELOG.md`** — `[Unreleased] → Added` documents the workflow + badge addition.

## Expected initial score

Based on the PR series' cumulative hardening, expect mid-to-high single digits. Known open trade-offs that cap the score below 10:

- **Code-Review: 0** — solo maintainer. No reviewer other than myself for PRs.
- **Fuzzing: 0** — not applicable to a deployment template with no executable code beyond a restore script.
- **CII-Best-Practices: 0** — not registered with the CII Best Practices badge program; diminishing returns for a solo-maintainer repo.
- **Branch-Protection: ?** — if branch protection on `main` requires PR review, Scorecard may score it partial (solo maintainer + required review is a self-inconsistent pattern).

These are honest trade-offs documented in SECURITY.md. The score is not a grade, it's a measurement.

## Verification (local)

- [x] `python3 -c "import yaml; yaml.safe_load(...)"` parses `scorecard.yml`, `deployment-verification.yml`, `dependabot.yml`.
- [x] All four action pins are commit SHAs (dereferenced for the two annotated tags) with `# vX.Y.Z` version comments.
- [x] README badge row: Deployment Verification → **OpenSSF Scorecard** → License (3 badges).

## Test plan (post-merge)

- [ ] First Scorecard workflow run fires on this merge's `push: main` trigger.
- [ ] Workflow completes successfully within ~2-5 minutes.
- [ ] README badge populates (initially may show "no data" for a few minutes).
- [ ] SARIF results appear under **Security → Code scanning** with category `scorecard`.
- [ ] Viewer at `https://scorecard.dev/viewer/?uri=github.com/heyvaldemar/keycloak-traefik-letsencrypt-docker-compose` resolves and shows per-check breakdown.

## After this merges

I'll author `REPO_POLISH_RUNBOOK.md` — a standalone document with exact find/replace patterns, shell snippets, and per-PR commit-message templates. Goal: applying this same 6-PR treatment to the remaining 30+ `-traefik-letsencrypt-docker-compose` repos takes **~3-5 hours each**, not the ~10-15 hours this first one took.

The runbook will cover:

- How to resolve upstream image digests (tag-object dereferencing included)
- The LICENSE / SECURITY / CHANGELOG / dependabot.yml templates with `{{REPO}}` / `{{SERVICE}}` placeholders
- The CI workflow hardening find/replace list
- The README rewrite template with evaluator-first skeleton
- The Scorecard workflow as a drop-in file
- Exact PR titles + commit messages + PR-body templates

Target repos for the rollout (ranked by stars, top 10):
- `nextcloud-traefik-letsencrypt-docker-compose` (91 stars)
- `zabbix-traefik-letsencrypt-docker-compose` (54 stars)
- `outline-keycloak-traefik-letsencrypt-docker-compose` (39 stars)
- `gitlab-traefik-letsencrypt-docker-compose` (33 stars)
- `gitea-traefik-letsencrypt-docker-compose` (33 stars)
- `minecraft-server-docker-compose` (32 stars)
- `rocketchat-traefik-letsencrypt-docker-compose` (28 stars)
- `jira-traefik-letsencrypt-docker-compose` (26 stars)
- `grafana-traefik-letsencrypt-docker-compose` (25 stars)
- `ollama-traefik-letsencrypt-docker-compose` (23 stars)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
