### PR TITLE
fix: correct README Quake-leftover typo + resolve shellcheck warnings

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,7 +62,7 @@ docker compose -f keycloak-traefik-letsencrypt-docker-compose.yml -p keycloak up
 
 Within a minute or two, both `https://${KEYCLOAK_HOSTNAME}` (Keycloak UI) and `https://${TRAEFIK_HOSTNAME}` (Traefik dashboard, basic-auth protected) are live with fresh Let's Encrypt certificates.
 
-Apply new `server.cfg` or compose changes:
+Apply `.env` or compose-file changes:
 
 ```bash
 docker compose -f keycloak-traefik-letsencrypt-docker-compose.yml -p keycloak up -d --force-recreate

--- a/keycloak-restore-database.sh
+++ b/keycloak-restore-database.sh
@@ -8,7 +8,7 @@
 # 4. **Stop Service**: Temporarily stops the service to ensure data consistency during restoration.
 # 5. **Restore Database**: Executes a sequence of commands to drop the current database, create a new one, and restore it from the selected compressed backup file.
 # 6. **Start Service**: Restarts the service after the restoration is completed.
-# To make the `keycloak-restore-database.shh` script executable, run the following command:
+# To make the `keycloak-restore-database.sh` script executable, run the following command:
 # `chmod +x keycloak-restore-database.sh`
 # Usage of this script ensures a controlled and guided process to restore the database from an existing backup.
 
@@ -16,8 +16,10 @@ KEYCLOAK_CONTAINER=$(docker ps -aqf "name=keycloak-keycloak")
 KEYCLOAK_BACKUPS_CONTAINER=$(docker ps -aqf "name=keycloak-backups")
 KEYCLOAK_DB_NAME="keycloakdb"
 KEYCLOAK_DB_USER="keycloakdbuser"
-POSTGRES_PASSWORD=$(docker exec $KEYCLOAK_BACKUPS_CONTAINER printenv PGPASSWORD)
 BACKUP_PATH="/srv/keycloak-postgres/backups/"
+
+# Note: PGPASSWORD is read from the backups container's environment at exec
+# time (psql inherits it inside `docker exec`). No need to surface it here.
 
 echo "--> All available database backups:"
 
@@ -30,7 +32,7 @@ echo "--> Copy and paste the backup name from the list above to restore database
 --> Example: keycloak-postgres-backup-YYYY-MM-DD_hh-mm.gz"
 echo -n "--> "
 
-read SELECTED_DATABASE_BACKUP
+read -r SELECTED_DATABASE_BACKUP
 
 echo "--> $SELECTED_DATABASE_BACKUP was selected"
 


### PR DESCRIPTION
## Summary

Two small cleanups surfaced after the 6-PR hardening series (#12-#17) landed. Fixing now so the reference implementation is clean before applying the same runbook to the other `-traefik-letsencrypt-docker-compose` repos.

## What changed per file

- **`README.md:65`** — Corrected a phrasing bug from the PR #16 README rewrite. The line previously read `"Apply new \`server.cfg\` or compose changes:"` — leftover from unrelated earlier work. This repo has no `server.cfg`; it has `.env` and the compose file. Corrected to `"Apply \`.env\` or compose-file changes:"`.

- **`keycloak-restore-database.sh`** — shellcheck now clean. Previously had 3 warnings:

  | Line | Rule | Issue | Fix |
  |---|---|---|---|
  | 19 | SC2034 + SC2086 | `POSTGRES_PASSWORD=$(docker exec ...)` assigns an unused variable, and `$KEYCLOAK_BACKUPS_CONTAINER` is unquoted inside the subshell. | **Removed the dead assignment entirely.** `PGPASSWORD` is already present in the backups container's environment; `psql` inherits it during `docker exec`. The outer shell never needed it. Added a comment explaining the pattern. |
  | 33 | SC2162 | `read SELECTED_DATABASE_BACKUP` without `-r` flag mangles backslashes in input. | Added `-r`. |
  | 11 (comment) | — | Typo in the comment: `keycloak-restore-database.shh` (double `h`). | Corrected to `keycloak-restore-database.sh`. |

## Verification (local)

- [x] `docker run --rm -v "$PWD:/mnt" -w /mnt koalaman/shellcheck-alpine:stable shellcheck keycloak-restore-database.sh` → clean.
- [x] `grep -n "server\.cfg" README.md` → no matches (was line 65 before this PR).
- [x] Git diff is narrowly scoped: 1 line in `README.md`, 5 lines in the restore script (one removed, two modified, plus the added comment).

## What did NOT change

- Restore flow behaviour: the script still identifies containers by name, lists backups, prompts for selection, stops keycloak, `dropdb → createdb → psql` pipeline, restarts keycloak. Same sequence, same commands to the backups container.
- No changes to compose, workflows, or `.env.example`.

## Test plan (post-merge)

- [ ] The `deployment-verification.yml` workflow runs green on the push to `main` (this PR doesn't touch CI; sanity-check only).
- [ ] If the deployer has backups to restore, the script still works:
  ```bash
  ./keycloak-restore-database.sh
  # Lists backups → prompts → restores → restarts. Same UX.
  ```

## Note for followers of the hardening series

This is a small correctness-only PR. The next PR in the series (#19) adds a `lint` job to the deployment-verification workflow (running shellcheck on `keycloak-restore-database.sh` in CI, plus `actionlint` on the workflows themselves), so future regressions of this kind get caught before merge. PR #19 also adds a `scan-trivy` job that runs Trivy against the pinned upstream images (`postgres:16@sha256:...`, `traefik:3.2@sha256:...`, `quay.io/keycloak/keycloak:26.2.5@sha256:...`) and uploads SARIF to the GitHub Security tab — closing the remaining supply-chain gap between this repo and the [aws-kubectl-docker](https://github.com/heyvaldemar/aws-kubectl-docker) reference.

After #19 merges, a companion PR on [self-host-repo-hardening-runbook](https://github.com/heyvaldemar/self-host-repo-hardening-runbook) will add a Phase 7 (lint + Trivy) to the runbook and ship v1.1.0, so the full 7-phase program is available for rolling out to the other 30+ deployment-template repos.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
