### PR TITLE
ci: add lint + Trivy upstream-image scan jobs

### DIFF
--- a/.github/workflows/deployment-verification.yml
+++ b/.github/workflows/deployment-verification.yml
@@ -21,9 +21,87 @@ permissions:
   contents: read
 
 jobs:
+  lint:
+    name: Lint shell scripts and workflow YAML
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    permissions:
+      contents: read
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+
+      - name: ShellCheck
+        # Uses the official koalaman/shellcheck-alpine image directly rather
+        # than an intermediate GitHub Action, so there is one less supply-chain
+        # layer to pin and review.
+        run: |
+          docker run --rm -v "$PWD:/mnt" -w /mnt \
+            koalaman/shellcheck-alpine:stable \
+            shellcheck ./*.sh
+
+      - name: actionlint (GitHub Actions workflow linting)
+        # Uses the rhysd/actionlint image directly pinned to a specific
+        # version. Surfaces workflow typos, invalid references to jobs/
+        # outputs, and common GitHub Actions footguns the YAML parser
+        # doesn't catch. actionlint itself is a single Go binary.
+        run: |
+          docker run --rm -v "$PWD:/mnt" -w /mnt \
+            rhysd/actionlint:1.7.12 \
+            -color
+
+  scan-trivy:
+    name: Scan pinned upstream image with Trivy
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    # Trivy findings don't block the pipeline — they surface in the Security
+    # tab where they can be triaged and fixed via Dependabot upstream-digest
+    # bumps. A hard block here would cause CI failures on every new CVE
+    # disclosure, which isn't actionable inside this PR.
+    continue-on-error: true
+    permissions:
+      contents: read
+      security-events: write
+    strategy:
+      # One job per upstream image — findings show up separately in the
+      # GitHub Security tab under distinct categories (trivy-postgres,
+      # trivy-traefik, trivy-keycloak).
+      fail-fast: false
+      matrix:
+        include:
+          - name: postgres
+            image: "postgres:16@sha256:71e27bf60b70bded003791b5573f8b808365613f341df20ffcf0c1ed7bc13ddf"
+          - name: traefik
+            image: "traefik:3.2@sha256:e561a37f8710d9cf41c78bdf421d822b2c0b48267ec0552e644565fb55466ea9"
+          - name: keycloak
+            image: "quay.io/keycloak/keycloak:26.2.5@sha256:4883630ef9db14031cde3e60700c9a9a8eaf1b5c24db1589d6a2d43de38ba2a9"
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+
+      - name: Trivy scan of ${{ matrix.name }}
+        uses: aquasecurity/trivy-action@57a97c7e7821a5776cebc9bb87c984fa69cba8f1 # v0.35.0
+        with:
+          image-ref: ${{ matrix.image }}
+          format: sarif
+          output: trivy-${{ matrix.name }}.sarif
+          severity: CRITICAL,HIGH
+          ignore-unfixed: true
+
+      - name: Upload Trivy SARIF (${{ matrix.name }}) to GitHub Security
+        uses: github/codeql-action/upload-sarif@95e58e9a2cdfd71adc6e0353d5c52f41a045d225 # v4.35.2
+        with:
+          sarif_file: trivy-${{ matrix.name }}.sarif
+          category: trivy-${{ matrix.name }}
+
   deploy-and-test:
     name: docker compose up + HTTPS + Traefik dashboard smoke
     runs-on: ubuntu-latest
+    # Wait for lint to pass so we don't burn the 15-minute compose-up slot
+    # on a workflow that has shellcheck/actionlint errors. scan-trivy runs
+    # in parallel (not a dependency) since findings don't block deployment.
+    needs: lint
     timeout-minutes: 15
     permissions:
       contents: read
@@ -85,6 +163,9 @@ jobs:
       - name: Wait for the application to be ready via Traefik
         run: |
           echo "Checking the routing and availability of the application via Traefik..."
+          # $APP_HOSTNAME is intentionally expanded by the inner bash -c
+          # (which inherits the job-level env:), not by the outer shell.
+          # shellcheck disable=SC2016
           timeout 5m bash -c 'while ! curl -fsSLk "https://$APP_HOSTNAME"; do
             echo "Waiting for the application to be ready..."
             sleep 10
@@ -93,6 +174,8 @@ jobs:
       - name: Wait for the Traefik dashboard to be ready
         run: |
           echo "Checking the routing and availability of the Traefik dashboard..."
+          # Same deferred-expansion pattern as above.
+          # shellcheck disable=SC2016
           timeout 5m bash -c 'while ! curl -fsSLk --write-out "%{http_code}" --output /dev/null "https://$APP_TRAEFIK_HOSTNAME" | grep -E "200|401"; do
             echo "Waiting for the application to be ready..."
             sleep 10

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,23 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `CHANGELOG.md` — this file, Keep-a-Changelog format.
 
 ### Changed
+- Deployment-verification workflow gained two new jobs:
+  - **`lint`** — runs `shellcheck` (via `koalaman/shellcheck-alpine:stable`) on
+    every `*.sh` in the repo root, and `actionlint` (via
+    `rhysd/actionlint:1.7.12`) on every workflow YAML. Blocks `deploy-and-test`
+    via `needs: lint` so CI fails fast on typos and footguns before burning
+    the 15-minute compose-up slot.
+  - **`scan-trivy`** — matrix job scanning each pinned upstream image
+    (`postgres:16@sha256:…`, `traefik:3.2@sha256:…`,
+    `quay.io/keycloak/keycloak:26.2.5@sha256:…`) for CRITICAL/HIGH fixable
+    CVEs via `aquasecurity/trivy-action@v0.35.0`, uploading per-image SARIF
+    to the GitHub Security tab under categories `trivy-postgres`,
+    `trivy-traefik`, `trivy-keycloak`. Runs parallel to `deploy-and-test`
+    with `continue-on-error: true` — findings don't block deployment but
+    surface for triage via Dependabot digest bumps.
+- Resolved pre-existing shellcheck warnings (SC2034, SC2086, SC2162) in
+  `keycloak-restore-database.sh`; fixed the README `server.cfg` leftover
+  phrasing. Both shipped in PR #18.
 - README rewritten for evaluator-first audience. Replaces the prior affiliate-and-socials-heavy footer with a focused technical structure: badges, table of contents, "Why this stack?" comparison table vs manual install / Helm / other compose examples, Getting started quickstart, Features + Typical use cases, Supply chain trust, Production checklist (7-item deployment-readiness check), preserved Backups and Restore sections, Security Notes, compact maintainer footer (YouTube · Blog · LinkedIn). Removes: first-person bio, "My Courses", "My Services", Patreon tiers, affiliate kit.co links, crypto wallet addresses, Discord invite, octocat gif, footer SVG.
 - Upstream images pinned by `sha256` digest in addition to tag in `.env.example`
   and the CI ephemeral `.env`. Three images are pinned:


### PR DESCRIPTION
## Summary

Adds two new CI jobs to `deployment-verification.yml`: **`lint`** (shellcheck + actionlint) and **`scan-trivy`** (matrix scan of the three pinned upstream images with SARIF upload to GitHub Security tab).

Closes the supply-chain gap between this deployment-template repo and the [`aws-kubectl-docker`](https://github.com/heyvaldemar/aws-kubectl-docker) image-publishing reference. After merge, the deployment-verification workflow matches `aws-kubectl-docker`'s `publish.yml` shape modulo the cosign/SBOM/SLSA steps that don't apply to a repo that doesn't publish its own image.

## Job topology (post-merge)

| Job | Deps | Parallel with | Blocks merge? |
|---|---|---|---|
| `lint` | — | — | ✅ yes |
| `scan-trivy` (matrix × 3) | — | `deploy-and-test` | ❌ `continue-on-error: true` |
| `deploy-and-test` | `lint` | `scan-trivy` | ✅ yes |

## What changed per file

- **`.github/workflows/deployment-verification.yml`**:

  - **New `lint` job** (blocking, 5-minute timeout):
    - `shellcheck` on every `*.sh` in the repo root via `koalaman/shellcheck-alpine:stable`. Direct docker image invocation — one less supply-chain layer to pin than using an intermediate GitHub Action.
    - `actionlint` on every workflow YAML via `rhysd/actionlint:1.7.12`. Catches typos, invalid step references, common GitHub Actions footguns the YAML parser doesn't catch.

  - **New `scan-trivy` job** (parallel to `deploy-and-test`, `continue-on-error: true`, 10-minute timeout):
    - Matrix job with 3 images. Each entry has a `name` (used for SARIF category) and an `image` (the full digest-pinned reference):

      | name | image |
      |---|---|
      | `postgres` | `postgres:16@sha256:71e27bf6…` |
      | `traefik` | `traefik:3.2@sha256:e561a37f…` |
      | `keycloak` | `quay.io/keycloak/keycloak:26.2.5@sha256:4883630e…` |

    - `aquasecurity/trivy-action@57a97c7e...` (pinned commit SHA, v0.35.0) scans each image for `CRITICAL,HIGH` severity CVEs, `ignore-unfixed: true` (no signal from CVEs without upstream fixes yet).
    - `github/codeql-action/upload-sarif@95e58e9a...` (pinned commit SHA, v4.35.2, matches scorecard.yml pin) uploads each image's SARIF to the GitHub Security tab under distinct categories — `trivy-postgres`, `trivy-traefik`, `trivy-keycloak` — for separate triage.
    - `fail-fast: false` on the matrix: one image scan failing doesn't cancel the other two.

  - **`deploy-and-test` job** now declares `needs: lint`. CI fails fast on shellcheck/actionlint errors before consuming the 15-minute compose-up slot.

  - **Run-block hygiene** (unrelated to the new jobs but needed to pass actionlint):
    Two existing `timeout 5m bash -c '...'` blocks (HTTP smoke checks) tripped shellcheck `SC2016` because `$APP_HOSTNAME` inside single quotes looks like a missed expansion. The deferred-expansion is intentional — the inner bash inherits the job-level `env:`. Added explicit `# shellcheck disable=SC2016` directives with rationale comments immediately before the affected `timeout` invocations.

- **`CHANGELOG.md`** — `[Unreleased] → Changed` entry documents the lint + scan-trivy jobs and back-fills PR #18's fixes.

## Design decisions worth calling out

**Why `continue-on-error: true` on `scan-trivy`?** A hard block would cause red CI on every new CVE disclosure — CVEs land against upstream images on a schedule the maintainer doesn't control. The actionable response to a Trivy finding is a Dependabot digest bump, which is already its own PR flow. The Security-tab findings surface for triage; they don't gate deployment.

**Why `needs: lint` on `deploy-and-test` but not on `scan-trivy`?** Lint errors indicate our CI is structurally broken; failing fast there makes sense. Trivy findings are about upstream images — they're not a reason to skip CI for our own changes.

**Why direct docker image invocation for shellcheck/actionlint, not a wrapping GitHub Action?** Fewer SHAs to pin. The two docker images are pinned to specific tags (`koalaman/shellcheck-alpine:stable`, `rhysd/actionlint:1.7.12`) and the actions tooling itself is a single Go binary in each image — minimal attack surface.

**Why three matrix entries instead of one script that scans all three?** Matrix gives each image its own job log, its own SARIF upload, and its own Security-tab category. Finding a CVE in `postgres` shouldn't show up under the `keycloak` category. Also — one scan failing doesn't block the other two (`fail-fast: false`).

## Verification (local)

- [x] `yaml.safe_load(...)` parses the workflow cleanly.
- [x] `docker run rhysd/actionlint:1.7.12` returns exit 0 with no output — clean.
- [x] `docker run koalaman/shellcheck-alpine:stable shellcheck ./*.sh` — clean.
- [x] Job-dependency topology confirmed: `lint` no-deps blocking, `scan-trivy` no-deps parallel continue-on-error, `deploy-and-test` needs `lint`.

## Test plan (post-merge)

- [ ] First post-merge run: `lint` job passes in <1 minute.
- [ ] `scan-trivy` runs 3 parallel matrix jobs; all complete within 10 minutes.
- [ ] `deploy-and-test` starts only after `lint` finishes.
- [ ] GitHub Security tab shows 3 distinct categories: `trivy-postgres`, `trivy-traefik`, `trivy-keycloak`.
- [ ] If Trivy finds CVEs, they appear under the right category. If none found (best case), categories show empty.
- [ ] Dependabot's weekly `docker` ecosystem PR, when it lands, bumps each digest; the next Trivy scan reflects the new digest's findings.

## Known residual work

- **Dependabot `docker` ecosystem auto-bumping**: the current `.env.example` puts digest pins in env-var form (`KEYCLOAK_IMAGE_TAG=image:tag@sha256:...`). Dependabot's docker ecosystem scans `Dockerfile` and `docker-compose.yml` for literal `image: <ref>` strings — it doesn't expand `${VAR}` references. So digest bumps aren't currently auto-PR'd. This is separate from this PR's scope; tracked as a follow-up consideration. Workarounds: inline the image tags in the compose file, migrate to Renovate bot (which does parse env files), or accept manual digest rotation.

## What's next

After this merges, one more companion PR on [`self-host-repo-hardening-runbook`](https://github.com/heyvaldemar/self-host-repo-hardening-runbook) adds Phase 7 (`lint` + `scan-trivy`) to the runbook and ships v1.1.0. That release makes the full 7-phase program available for rolling out to the other 30+ deployment-template repos.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
