### PR TITLE
docs(security): sync SECURITY.md Supply Chain Trust with runbook v1.2 template

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -58,6 +58,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   (`0 6 * * 1`) for upstream image drift detection, and `workflow_dispatch`
   trigger for manual runs. Workflow file renamed `00-deployment-verification.yml`
   → `deployment-verification.yml`.
+- `SECURITY.md` Supply Chain Trust section synced with
+  [self-host-repo-hardening-runbook v1.2](https://github.com/heyvaldemar/self-host-repo-hardening-runbook/releases/tag/v1.2.0)
+  template. Replaces the stale "will migrate to immutable `@sha256:...` digests
+  in an upcoming PR" language (that migration shipped in PR #14) with the
+  current-state description: digests pinned in `.env.example`, Dependabot
+  weekly bumps, CI weekly drift detection. Adds the GitHub-Actions-pinned-by-
+  commit-SHA statement that the template now includes.
 
 ### Removed
 - `.github/FUNDING.yml` — sponsor discovery moves to heyvaldemar.com. Aligns with the same decision applied across other heyvaldemar public repositories.

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -25,7 +25,9 @@ This repository publishes a **deployment template**, not a custom Docker image. 
 - [`quay.io/keycloak/keycloak`](https://quay.io/repository/keycloak/keycloak) — Keycloak upstream
 - [`postgres`](https://hub.docker.com/_/postgres) — PostgreSQL, official image
 
-Upstream image tags are pinned to specific versions and will migrate to immutable `@sha256:...` digests in an upcoming PR. Dependabot's `docker` ecosystem tracks digest bumps weekly.
+Upstream image tags are pinned to `tag@sha256:<digest>` in `.env.example`. Dependabot's `docker` ecosystem tracks digest bumps weekly. CI's Deployment Verification workflow stands up the full compose stack on every push and every Monday at 06:00 UTC, catching upstream drift before it reaches users.
+
+GitHub Actions are pinned by commit SHA with `# vX.Y.Z` version comments.
 
 ## Known historical issue
 


### PR DESCRIPTION
## Summary

One-line drift closed — SECURITY.md's **Supply Chain Trust** section still said digests *"will migrate to immutable `@sha256:...` digests in an upcoming PR"*, but that migration shipped in [PR #14](https://github.com/heyvaldemar/keycloak-traefik-letsencrypt-docker-compose/pull/14) (merged 2026-04-23). The "upcoming" wording has been ~6 weeks stale.

Identified during the post-release audit of this reference-implementation against the new [self-host-repo-hardening-runbook v1.2.0](https://github.com/heyvaldemar/self-host-repo-hardening-runbook/releases/tag/v1.2.0).

## What changes

**`SECURITY.md` line 28** — replaced with the current-state description from `templates/SECURITY.md.tmpl`:

```diff
-Upstream image tags are pinned to specific versions and will migrate to immutable `@sha256:...` digests in an upcoming PR. Dependabot's `docker` ecosystem tracks digest bumps weekly.
+Upstream image tags are pinned to `tag@sha256:<digest>` in `.env.example`. Dependabot's `docker` ecosystem tracks digest bumps weekly. CI's Deployment Verification workflow stands up the full compose stack on every push and every Monday at 06:00 UTC, catching upstream drift before it reaches users.
+
+GitHub Actions are pinned by commit SHA with `# vX.Y.Z` version comments.
```

Now describes what's actually shipped:

- **Digests pinned** in `.env.example` (PR #14)
- **Dependabot `docker` ecosystem** weekly bumps (PR #13)
- **CI weekly drift detection** — Monday 06:00 UTC cron on the deployment-verification workflow (PR #15)
- **GitHub Actions pinned by commit SHA** — PR #15 + PR #19 (scorecard.yml + lint/scan-trivy additions)

**`CHANGELOG.md`** — one bullet under `[Unreleased] → Changed` documenting the sync, with a link to the runbook v1.2.0 release.

## Verification

- [x] Diff matches the runbook template exactly for this section.
- [x] No functional change — purely docs. No workflow or code touched.
- [x] Other repo elements remain template-compliant (verified during the audit: LICENSE, CHANGELOG, dependabot.yml, scorecard.yml, deployment-verification.yml, README all match).

## Scope

Intentionally minimal. This PR closes one specific drift item. No other cleanup bundled.

```
CHANGELOG.md | 7 +++++++
SECURITY.md  | 4 +++-
2 files changed, 10 insertions(+), 1 deletion(-)
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)