### PR TITLE
feat: end-to-end CI tests for backup/restore flow

### DIFF
--- a/.github/workflows/deployment-verification.yml
+++ b/.github/workflows/deployment-verification.yml
@@ -34,11 +34,12 @@ jobs:
       - name: ShellCheck
         # Uses the official koalaman/shellcheck-alpine image directly rather
         # than an intermediate GitHub Action, so there is one less supply-chain
-        # layer to pin and review.
+        # layer to pin and review. Covers both repo-root scripts and the
+        # tests/ directory so the backup-restore-e2e runner is linted too.
         run: |
           docker run --rm -v "$PWD:/mnt" -w /mnt \
             koalaman/shellcheck-alpine:stable \
-            shellcheck ./*.sh
+            shellcheck ./*.sh tests/*.sh
 
       - name: actionlint (GitHub Actions workflow linting)
         # Uses the rhysd/actionlint image directly pinned to a specific
@@ -185,6 +186,93 @@ jobs:
         run: |
           docker network inspect "$NETWORK_ONE"
           docker network inspect "$NETWORK_TWO"
+
+      - name: Show container logs on failure
+        if: failure()
+        run: docker compose -f "$DOCKER_COMPOSE_FILE" -p "$COMPOSE_PROJECT_NAME" logs
+
+      - name: Shutdown Docker Compose services
+        if: always()
+        run: docker compose -f "$DOCKER_COMPOSE_FILE" -p "$COMPOSE_PROJECT_NAME" down
+
+  backup-restore-e2e:
+    name: Backup + restore end-to-end smoke
+    runs-on: ubuntu-latest
+    # Parallel to deploy-and-test — backup/restore is orthogonal to HTTPS
+    # routing, so one job failing doesn't mask the other. Both fan out from
+    # `lint` so we don't burn the compose-up slot on a workflow with
+    # shellcheck/actionlint errors.
+    needs: lint
+    timeout-minutes: 15
+    permissions:
+      contents: read
+
+    env:
+      NETWORK_ONE: keycloak-network
+      NETWORK_TWO: traefik-network
+      DOCKER_COMPOSE_FILE: keycloak-traefik-letsencrypt-docker-compose.yml
+      COMPOSE_PROJECT_NAME: keycloak
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+
+      - name: Create necessary Docker networks
+        run: |
+          docker network create "$NETWORK_ONE" || true
+          docker network create "$NETWORK_TWO" || true
+
+      - name: Generate test .env with short backup intervals
+        # CI tunes the backup loop timings from 30m/24h down to 10s/30s so
+        # the backup cycle tests can complete in <5 min wall-clock. The
+        # hostnames here are placeholder — this job never exercises Traefik
+        # or Keycloak HTTPS routing (that's deploy-and-test's responsibility).
+        run: |
+          cat > .env <<EOF
+          TRAEFIK_IMAGE_TAG=traefik:3.2@sha256:e561a37f8710d9cf41c78bdf421d822b2c0b48267ec0552e644565fb55466ea9
+          TRAEFIK_LOG_LEVEL=WARN
+          TRAEFIK_ACME_EMAIL=ci@example.com
+          TRAEFIK_HOSTNAME=traefik.keycloak.ci.example
+          TRAEFIK_BASIC_AUTH=traefikadmin:\$\$2y\$\$10\$\$sMzJfirKC75x/hVpiINeZOiSm.Jkity9cn4KwNkRvO7hSQVFc5FLO
+          KEYCLOAK_POSTGRES_IMAGE_TAG=postgres:16@sha256:71e27bf60b70bded003791b5573f8b808365613f341df20ffcf0c1ed7bc13ddf
+          KEYCLOAK_IMAGE_TAG=quay.io/keycloak/keycloak:26.2.5@sha256:4883630ef9db14031cde3e60700c9a9a8eaf1b5c24db1589d6a2d43de38ba2a9
+          KEYCLOAK_DB_NAME=keycloakdb
+          KEYCLOAK_DB_USER=keycloakdbuser
+          KEYCLOAK_DB_PASSWORD=$(openssl rand -base64 24 | tr -d '/+=' | head -c 32)
+          KEYCLOAK_ADMIN_USERNAME=keycloakadmin
+          KEYCLOAK_ADMIN_PASSWORD=$(openssl rand -base64 24 | tr -d '/+=' | head -c 32)
+          KEYCLOAK_HOSTNAME=keycloak.ci.example
+          KEYCLOAK_BACKUP_INIT_SLEEP=10s
+          KEYCLOAK_BACKUP_INTERVAL=30s
+          KEYCLOAK_POSTGRES_BACKUP_PRUNE_DAYS=7
+          KEYCLOAK_POSTGRES_BACKUPS_PATH=/srv/keycloak-postgres/backups
+          KEYCLOAK_POSTGRES_BACKUP_NAME=keycloak-postgres-backup
+          EOF
+
+      - name: Start up services using Docker Compose
+        run: docker compose -f "$DOCKER_COMPOSE_FILE" -p "$COMPOSE_PROJECT_NAME" up -d
+
+      - name: Wait for postgres to become healthy
+        # docker compose --wait would be nicer but isn't universally
+        # available on the runner's compose version. Polling pg_isready
+        # is equivalent and works everywhere.
+        run: |
+          for i in $(seq 1 60); do
+            if docker exec "$(docker ps -aqf "name=${COMPOSE_PROJECT_NAME}-postgres" | head -1)" \
+                pg_isready -q -U keycloakdbuser -d keycloakdb > /dev/null 2>&1; then
+              echo "postgres ready after ${i} attempts"
+              exit 0
+            fi
+            sleep 2
+          done
+          echo "postgres did not become ready within 120s" >&2
+          exit 1
+
+      - name: Print Docker Compose services status
+        run: docker ps
+
+      - name: Run backup/restore E2E tests
+        run: ./tests/e2e-backup-restore.sh
 
       - name: Show container logs on failure
         if: failure()

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,50 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+- **Compose interpolation bug in the `backups` service command.** PR #21
+  introduced two local container-shell variables (`$BACKUP_FILE`, `$SIZE`)
+  inside the `command: >-` block without `$$` escapes. Docker compose
+  interpolated them at config time against the empty .env values and
+  produced `BACKUP_FILE=""` at container runtime — every backup cycle ran
+  `pg_dump | gzip > ""` and emitted `Backup FAILED` with
+  `sh: cannot create : Directory nonexistent`. Zero-byte files never landed,
+  so the `backup-created` test case surfaced the regression on the first CI
+  run. Fix: escape every container-shell reference in the command with `$$`
+  (including the pre-existing `$KEYCLOAK_*` vars that happen to also appear
+  in the `environment:` block). Added a block comment in the compose file
+  explaining the escape convention so future edits don't reintroduce the
+  same bug.
+
 ### Added
+- **End-to-end backup/restore CI tests.** New `backup-restore-e2e` job in
+  `deployment-verification.yml` runs `tests/e2e-backup-restore.sh` on every
+  push, pull request, and the Monday weekly cron. Parallel to
+  `deploy-and-test` — backup/restore is orthogonal to HTTPS routing, so one
+  failing doesn't mask the other; both fan out from `needs: lint` so the
+  compose-up slot isn't burned on workflow-syntax errors. The job generates
+  an ephemeral `.env` with short backup intervals
+  (`INIT_SLEEP=10s`, `INTERVAL=30s`, `PRUNE_DAYS=7`) so the seven-test suite
+  completes in <5 min wall-clock. `timeout-minutes: 15`, 
+  `permissions: contents: read`, `docker compose down` in an
+  `if: always()` teardown step.
+- `tests/e2e-backup-restore.sh` — seven shellcheck-clean test cases that
+  exercise every guard PR #21 landed: `test_env_required` (compose `${VAR:?}`
+  gate), `test_backup_created` (cycle produces non-empty `.gz`),
+  `test_backup_gunzip_ok` (archive is a valid gzip stream),
+  `test_backup_sql_valid` (decompressed dump has `PostgreSQL database dump` +
+  `CREATE TABLE`/`CREATE SCHEMA`), `test_backup_failure_detected` (stopping
+  postgres produces a `*.failed` file and `Backup FAILED` log line),
+  `test_restore_roundtrip` (insert marker → restore earlier backup → marker
+  absent, proving restore is not a no-op), `test_prune_removes_old` (fake
+  file with 14-day-old mtime is deleted on next prune cycle; recent backups
+  preserved).
+- `tests/README.md` — local-run instructions, test-case descriptions, and
+  required `.env` timing knobs.
+- README `Testing` section between Restoring and Security Notes; TOC updated.
+- The `lint` job's shellcheck invocation now covers `tests/*.sh` in addition
+  to repo-root `*.sh` so the e2e test runner is linted alongside the
+  restore script.
 - `.github/workflows/scorecard.yml` — OpenSSF Scorecard analysis workflow.
   Runs weekly on Tuesdays at 06:00 UTC (one day after the Monday deployment
   verification run), on every push to `main`, and on branch-protection-rule

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Fixed
+- **Backup filename collision at sub-minute intervals.** Backup filenames
+  use only minute granularity
+  (`keycloak-postgres-backup-YYYY-MM-DD_HH-MM.gz`), so two cycles inside
+  the same minute produced identical paths and the second overwrote the
+  first. At production defaults (`INTERVAL=24h`) the bug is unreachable,
+  but the new e2e test harness drives `INTERVAL=30s` and surfaced it on
+  the first run — `test_backup_failure_detected` renamed the previously
+  successful backup to `.failed` because pg_dump's partial output landed
+  at the same filename. Fix: timestamp format extended to include seconds
+  (`YYYY-MM-DD_HH-MM-SS.gz`). Prune glob pattern still matches. Restore
+  script's example filename updated; README's expected-log-output example
+  updated.
 - **Compose interpolation bug in the `backups` service command.** PR #21
   introduced two local container-shell variables (`$BACKUP_FILE`, `$SIZE`)
   inside the `command: >-` block without `$$` escapes. Docker compose

--- a/README.md
+++ b/README.md
@@ -135,8 +135,8 @@ docker compose -p keycloak logs backups | tail -20
 Expected output — one timestamped line per backup cycle:
 
 ```
-[2026-04-23T03:00:01+00:00] Starting backup to /srv/keycloak-postgres/backups/keycloak-postgres-backup-2026-04-23_03-00.gz
-[2026-04-23T03:00:03+00:00] Backup OK: /srv/keycloak-postgres/backups/keycloak-postgres-backup-2026-04-23_03-00.gz (47382 bytes)
+[2026-04-23T03:00:01+00:00] Starting backup to /srv/keycloak-postgres/backups/keycloak-postgres-backup-2026-04-23_03-00-01.gz
+[2026-04-23T03:00:03+00:00] Backup OK: /srv/keycloak-postgres/backups/keycloak-postgres-backup-2026-04-23_03-00-01.gz (47382 bytes)
 ```
 
 A `Backup FAILED` line (with the partial file renamed to `.failed`) is your signal that something is broken — typically the postgres container is unhealthy, the backup volume filled up, or the DB credentials were rotated without updating the backups container environment.

--- a/README.md
+++ b/README.md
@@ -14,6 +14,7 @@
 - [Production checklist](#production-checklist)
 - [Backups](#backups)
 - [Restoring a database backup](#restoring-a-database-backup)
+- [Testing](#testing)
 - [Security Notes](#security-notes)
 - [About the maintainer](#about-the-maintainer)
 
@@ -33,7 +34,7 @@ This repository deploys **Keycloak** behind **Traefik** with automatic **Let's E
 | One-command restore script | ✅ | Manual `pg_restore` | Manual | Rare |
 | Upstream images pinned by `sha256` digest | ✅ | N/A | Depends on chart | Rare |
 | Dependabot-tracked weekly updates | ✅ | N/A | Depends | Rare |
-| CI-verified deployment on every push | ✅ | N/A | Varies | Rare |
+| CI-verified deployment + backup/restore on every push | ✅ | N/A | Varies | Rare |
 | Credentials via env (never committed) | ✅ | N/A | K8s Secrets | Often committed plaintext |
 
 Four moving parts (Traefik + Keycloak + Postgres + backups). No hidden complexity, no Kubernetes prerequisites, no manual certificate management.
@@ -182,6 +183,28 @@ The script uses the `PGPASSWORD` inherited from the backups container, so no cre
 | **RTO** (typical restore time) | 1-3 minutes on a small DB; scales with DB size | Keep Keycloak state lean (realms + clients only, ship audit logs elsewhere) |
 | **Backup retention** | 7 days (one `PRUNE_DAYS`) | Increase `KEYCLOAK_POSTGRES_BACKUP_PRUNE_DAYS` |
 | **Pre-restore snapshot** | Automatic before every restore, kept at `/tmp/pre-restore-*.gz` inside the backups container | — |
+
+## Testing
+
+The [Deployment Verification](https://github.com/heyvaldemar/keycloak-traefik-letsencrypt-docker-compose/actions/workflows/deployment-verification.yml?query=branch%3Amain) workflow runs end-to-end backup + restore tests on every push, every pull request, and every Monday at 06:00 UTC. The `backup-restore-e2e` job boots the full compose stack with ephemeral credentials and short backup intervals (`INIT_SLEEP=10s`, `INTERVAL=30s`, `PRUNE_DAYS=7`) and exercises seven scenarios:
+
+1. **`.env` required** — `docker compose config` fails cleanly without `.env`, guarding the `${VAR:?...}` compose syntax.
+2. **Backup created** — a `.gz` appears in the backups volume with size > 0.
+3. **Backup integrity** — `gunzip -t` on the backup exits zero.
+4. **Backup contents valid** — decompressed SQL contains `PostgreSQL database dump` header and `CREATE TABLE`/`CREATE SCHEMA`.
+5. **Backup failure detected** — stopping postgres forces a failed cycle; a `*.failed` file and `Backup FAILED` log line are produced.
+6. **Restore roundtrip** — inserting a marker row, restoring an earlier backup, and asserting the marker is gone proves the backup is genuinely restorable (not a no-op).
+7. **Prune removes old** — a fake file with 14-day-old mtime is deleted on the next prune cycle; recent backups are preserved.
+
+Run the same tests locally:
+
+```bash
+# Bring the stack up first, with short backup intervals in .env — see tests/README.md
+docker compose -f keycloak-traefik-letsencrypt-docker-compose.yml -p keycloak up -d
+./tests/e2e-backup-restore.sh
+```
+
+A green [`backup-restore-e2e`](https://github.com/heyvaldemar/keycloak-traefik-letsencrypt-docker-compose/actions/workflows/deployment-verification.yml?query=branch%3Amain) run is the authoritative proof that the backup + restore flow works end-to-end on every push. If you deploy this template and hit an unexpected issue, compare the green CI run's logs to your own — most "doesn't work" cases trace to DNS propagation, firewall rules, hostname mismatches, or a customised `.env` that silently breaks a variable the tests cover.
 
 ## Security Notes
 

--- a/keycloak-restore-database.sh
+++ b/keycloak-restore-database.sh
@@ -92,7 +92,7 @@ done
 
 echo
 echo "--> Copy and paste the backup name from the list above, then press [ENTER]."
-echo "    Example: keycloak-postgres-backup-YYYY-MM-DD_hh-mm.gz"
+echo "    Example: keycloak-postgres-backup-YYYY-MM-DD_hh-mm-ss.gz"
 echo -n "--> "
 read -r SELECTED_BACKUP
 

--- a/keycloak-traefik-letsencrypt-docker-compose.yml
+++ b/keycloak-traefik-letsencrypt-docker-compose.yml
@@ -170,23 +170,31 @@ services:
     #     accidentally delete files with unrelated names.
     #   - PRUNE_DAYS=0 disables pruning entirely (guard against the "PRUNE_DAYS=0
     #     deletes everything" misconfiguration).
+    #
+    # `$$VAR` / `$$(...)` escapes are required so docker compose does NOT
+    # interpolate these — they must be resolved by the container shell at
+    # runtime from the environment passed via the `environment:` block below.
+    # Local variables ($$BACKUP_FILE, $$SIZE, $$(date ...)) are container-shell
+    # constructs with no compose-file equivalent; without the double-dollar
+    # escape compose substitutes them with empty strings and the backup loop
+    # produces zero-byte files at an empty path.
     command: >-
       sh -c 'set -o pipefail;
-      sleep "$KEYCLOAK_BACKUP_INIT_SLEEP";
+      sleep "$$KEYCLOAK_BACKUP_INIT_SLEEP";
       while true; do
-        BACKUP_FILE="$KEYCLOAK_POSTGRES_BACKUPS_PATH/$KEYCLOAK_POSTGRES_BACKUP_NAME-$(date +%Y-%m-%d_%H-%M).gz";
-        echo "[$(date -Iseconds)] Starting backup to $BACKUP_FILE";
-        if pg_dump -h postgres -p 5432 -d "$KEYCLOAK_DB_NAME" -U "$KEYCLOAK_DB_USER" | gzip > "$BACKUP_FILE"; then
-          SIZE=$(stat -c %s "$BACKUP_FILE" 2>/dev/null || echo ?);
-          echo "[$(date -Iseconds)] Backup OK: $BACKUP_FILE ($SIZE bytes)";
+        BACKUP_FILE="$$KEYCLOAK_POSTGRES_BACKUPS_PATH/$$KEYCLOAK_POSTGRES_BACKUP_NAME-$$(date +%Y-%m-%d_%H-%M).gz";
+        echo "[$$(date -Iseconds)] Starting backup to $$BACKUP_FILE";
+        if pg_dump -h postgres -p 5432 -d "$$KEYCLOAK_DB_NAME" -U "$$KEYCLOAK_DB_USER" | gzip > "$$BACKUP_FILE"; then
+          SIZE=$$(stat -c %s "$$BACKUP_FILE" 2>/dev/null || echo ?);
+          echo "[$$(date -Iseconds)] Backup OK: $$BACKUP_FILE ($$SIZE bytes)";
         else
-          echo "[$(date -Iseconds)] Backup FAILED — renaming partial file to .failed for diagnosis" >&2;
-          mv "$BACKUP_FILE" "${BACKUP_FILE}.failed" 2>/dev/null || true;
+          echo "[$$(date -Iseconds)] Backup FAILED — renaming partial file to .failed for diagnosis" >&2;
+          mv "$$BACKUP_FILE" "$${BACKUP_FILE}.failed" 2>/dev/null || true;
         fi;
-        if [ "${KEYCLOAK_POSTGRES_BACKUP_PRUNE_DAYS:-0}" -ge 1 ]; then
-          find "$KEYCLOAK_POSTGRES_BACKUPS_PATH" -type f -name "${KEYCLOAK_POSTGRES_BACKUP_NAME}-*.gz" -mtime "+${KEYCLOAK_POSTGRES_BACKUP_PRUNE_DAYS}" -delete;
+        if [ "$${KEYCLOAK_POSTGRES_BACKUP_PRUNE_DAYS:-0}" -ge 1 ]; then
+          find "$$KEYCLOAK_POSTGRES_BACKUPS_PATH" -type f -name "$${KEYCLOAK_POSTGRES_BACKUP_NAME}-*.gz" -mtime "+$${KEYCLOAK_POSTGRES_BACKUP_PRUNE_DAYS}" -delete;
         fi;
-        sleep "$KEYCLOAK_BACKUP_INTERVAL";
+        sleep "$$KEYCLOAK_BACKUP_INTERVAL";
       done'
     volumes:
       - keycloak-postgres-backup:/var/lib/postgresql/data

--- a/keycloak-traefik-letsencrypt-docker-compose.yml
+++ b/keycloak-traefik-letsencrypt-docker-compose.yml
@@ -182,7 +182,7 @@ services:
       sh -c 'set -o pipefail;
       sleep "$$KEYCLOAK_BACKUP_INIT_SLEEP";
       while true; do
-        BACKUP_FILE="$$KEYCLOAK_POSTGRES_BACKUPS_PATH/$$KEYCLOAK_POSTGRES_BACKUP_NAME-$$(date +%Y-%m-%d_%H-%M).gz";
+        BACKUP_FILE="$$KEYCLOAK_POSTGRES_BACKUPS_PATH/$$KEYCLOAK_POSTGRES_BACKUP_NAME-$$(date +%Y-%m-%d_%H-%M-%S).gz";
         echo "[$$(date -Iseconds)] Starting backup to $$BACKUP_FILE";
         if pg_dump -h postgres -p 5432 -d "$$KEYCLOAK_DB_NAME" -U "$$KEYCLOAK_DB_USER" | gzip > "$$BACKUP_FILE"; then
           SIZE=$$(stat -c %s "$$BACKUP_FILE" 2>/dev/null || echo ?);

--- a/tests/README.md
+++ b/tests/README.md
@@ -1,0 +1,65 @@
+# Tests
+
+End-to-end smoke tests for the Keycloak backup + restore flow. Exercises the
+safety guards that landed in [PR #21](https://github.com/heyvaldemar/keycloak-traefik-letsencrypt-docker-compose/pull/21) so a green CI run is the authoritative
+proof that the flow works on every push.
+
+## What's covered
+
+`e2e-backup-restore.sh` runs seven test cases against a live `docker compose`
+stack:
+
+1. **`test_env_required`** — `docker compose config` fails with a helpful error
+   when `.env` is absent. Guards the `${VAR:?set in .env...}` compose syntax.
+2. **`test_backup_created`** — a `.gz` file with size > 0 appears in the
+   backups volume within 120 seconds.
+3. **`test_backup_gunzip_ok`** — `gunzip -t` on the first backup exits zero
+   (not a zero-byte or truncated file).
+4. **`test_backup_sql_valid`** — the first 50 lines of the decompressed dump
+   contain `PostgreSQL database dump` and a `CREATE TABLE` or
+   `CREATE SCHEMA` statement.
+5. **`test_backup_failure_detected`** — stops postgres to force a failed
+   backup cycle, asserts a `*.failed` file is produced and the `Backup FAILED`
+   log line appears. Restarts postgres afterward.
+6. **`test_restore_roundtrip`** — inserts a marker row, restores an earlier
+   backup directly via `docker exec` (bypassing the interactive `DESTROY`
+   prompt in `keycloak-restore-database.sh`), asserts the marker row is gone.
+   End-to-end proof the backup is genuinely restorable — not a no-op.
+7. **`test_prune_removes_old`** — places a fake file with `mtime` 14 days ago,
+   waits for the next prune cycle, asserts the fake is gone and recent
+   backups are still present.
+
+## Prerequisites
+
+- Docker Engine + Docker Compose v2.
+- `keycloak-network` and `traefik-network` already created (`docker network create`).
+- A `.env` file at the repo root with backup intervals tuned for the test
+  timings. The tests assume:
+
+  ```
+  KEYCLOAK_BACKUP_INIT_SLEEP=10s
+  KEYCLOAK_BACKUP_INTERVAL=30s
+  KEYCLOAK_POSTGRES_BACKUP_PRUNE_DAYS=7
+  ```
+
+  The production defaults (`30m` warm-up, `24h` interval) would make the
+  first-backup check time out. CI generates its own `.env` with these short
+  intervals — see `.github/workflows/deployment-verification.yml`.
+
+## Run locally
+
+From the repo root:
+
+```bash
+docker compose -f keycloak-traefik-letsencrypt-docker-compose.yml -p keycloak up -d
+./tests/e2e-backup-restore.sh
+```
+
+Expected runtime: 3-5 minutes (most of it waiting on backup cycles).
+
+## Run in CI
+
+The `backup-restore-e2e` job in `.github/workflows/deployment-verification.yml`
+runs this same script on every push, every pull request, and every Monday
+at 06:00 UTC. The job is parallel to `deploy-and-test` — backup/restore is
+orthogonal to HTTPS routing, so both run on `needs: lint`.

--- a/tests/e2e-backup-restore.sh
+++ b/tests/e2e-backup-restore.sh
@@ -130,6 +130,25 @@ wait_for_postgres_ready() {
   return 1
 }
 
+# The first backup cycle fires ~INIT_SLEEP (10s in CI) after the backups
+# container starts — which on a cold runner is often BEFORE Keycloak
+# finishes populating its public schema. Without a guaranteed table in the
+# DB, the first backup's SQL body is just headers + SETs, and
+# test_backup_sql_valid fails looking for CREATE TABLE. Creating a marker
+# table at test-setup time pins a CREATE TABLE statement into every
+# backup captured from now on, independent of Keycloak's own startup race.
+setup_marker_table() {
+  echo "--> creating backup_sql_valid_marker so every backup has CREATE TABLE content"
+  if ! docker exec "$BACKUPS_CONTAINER" psql \
+      -h postgres -p 5432 \
+      -U "$KEYCLOAK_DB_USER" -d "$KEYCLOAK_DB_NAME" \
+      -c "CREATE TABLE IF NOT EXISTS backup_sql_valid_marker (id int PRIMARY KEY);" \
+      > /dev/null; then
+    echo "error: failed to create marker table" >&2
+    exit 1
+  fi
+}
+
 # --- Test cases ---
 
 test_env_required() {
@@ -331,6 +350,10 @@ echo "  BACKUPS_CONTAINER=${BACKUPS_CONTAINER}"
 echo "  POSTGRES_CONTAINER=${POSTGRES_CONTAINER}"
 echo "  BACKUPS_PATH=${BACKUPS_PATH}"
 echo "  BACKUP_PREFIX=${BACKUP_PREFIX}"
+
+# Pin a known CREATE TABLE into the DB before the first backup cycle fires
+# (explanation in setup_marker_table).
+setup_marker_table
 
 run_test test_env_required
 run_test test_backup_created

--- a/tests/e2e-backup-restore.sh
+++ b/tests/e2e-backup-restore.sh
@@ -1,0 +1,355 @@
+#!/usr/bin/env bash
+#
+# End-to-end tests for the Keycloak backup + restore flow.
+#
+# Requires: docker, docker compose. Assumes the stack is already up with
+# short ephemeral backup intervals: INIT_SLEEP=10s, INTERVAL=30s, PRUNE_DAYS=7.
+#
+# Run from the repository root:
+#   ./tests/e2e-backup-restore.sh
+#
+# CI runs the same script on every push via the backup-restore-e2e job
+# in .github/workflows/deployment-verification.yml.
+
+# Tests and helpers are dispatched indirectly via run_test "$name"; shellcheck
+# can't trace that and flags every function as unused (SC2329).
+# shellcheck disable=SC2329
+
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+cd "$REPO_ROOT"
+
+COMPOSE_PROJECT_NAME="${COMPOSE_PROJECT_NAME:-keycloak}"
+DOCKER_COMPOSE_FILE="${DOCKER_COMPOSE_FILE:-keycloak-traefik-letsencrypt-docker-compose.yml}"
+
+# Source .env so KEYCLOAK_DB_USER, KEYCLOAK_DB_NAME,
+# KEYCLOAK_POSTGRES_BACKUPS_PATH, and KEYCLOAK_POSTGRES_BACKUP_NAME are in
+# this shell's environment for the helpers below.
+if [[ -f .env ]]; then
+  set -o allexport
+  # shellcheck disable=SC1091
+  source .env
+  set +o allexport
+else
+  echo "error: .env not found at $REPO_ROOT/.env" >&2
+  echo "       bring the stack up with a populated .env before running tests." >&2
+  exit 1
+fi
+
+: "${KEYCLOAK_DB_USER:?set in .env}"
+: "${KEYCLOAK_DB_NAME:?set in .env}"
+: "${KEYCLOAK_POSTGRES_BACKUPS_PATH:?set in .env}"
+: "${KEYCLOAK_POSTGRES_BACKUP_NAME:?set in .env}"
+
+BACKUPS_PATH="${KEYCLOAK_POSTGRES_BACKUPS_PATH%/}"
+BACKUP_PREFIX="${KEYCLOAK_POSTGRES_BACKUP_NAME}"
+
+BACKUPS_CONTAINER="$(docker ps -aqf "name=${COMPOSE_PROJECT_NAME}-backups" | head -n 1)"
+POSTGRES_CONTAINER="$(docker ps -aqf "name=${COMPOSE_PROJECT_NAME}-postgres" | head -n 1)"
+
+if [[ -z "$BACKUPS_CONTAINER" ]]; then
+  echo "error: backups container not found (COMPOSE_PROJECT_NAME=${COMPOSE_PROJECT_NAME})" >&2
+  exit 1
+fi
+if [[ -z "$POSTGRES_CONTAINER" ]]; then
+  echo "error: postgres container not found (COMPOSE_PROJECT_NAME=${COMPOSE_PROJECT_NAME})" >&2
+  exit 1
+fi
+
+# --- Test runner ---
+
+PASSED=0
+FAILED=0
+FAILURES=()
+
+run_test() {
+  local name="$1"
+  echo
+  echo "=== $name ==="
+  if "$name"; then
+    echo "  PASS: $name"
+    PASSED=$((PASSED + 1))
+  else
+    echo "  FAIL: $name" >&2
+    FAILED=$((FAILED + 1))
+    FAILURES+=("$name")
+  fi
+}
+
+fail() {
+  echo "  ASSERT: $*" >&2
+  return 1
+}
+
+# --- Container helpers ---
+
+backups_sh() {
+  docker exec "$BACKUPS_CONTAINER" sh -c "$1"
+}
+
+psql_query() {
+  docker exec "$BACKUPS_CONTAINER" psql \
+    -h postgres -p 5432 \
+    -U "$KEYCLOAK_DB_USER" -d "$KEYCLOAK_DB_NAME" \
+    -tAc "$1"
+}
+
+list_backups() {
+  backups_sh "ls -1 ${BACKUPS_PATH}/${BACKUP_PREFIX}-*.gz 2>/dev/null" \
+    | grep -v '\.failed$' \
+    | sort \
+    || true
+}
+
+wait_for_first_backup() {
+  local timeout="${1:-120}"
+  local elapsed=0
+  while [[ $elapsed -lt $timeout ]]; do
+    if [[ -n "$(list_backups)" ]]; then
+      return 0
+    fi
+    sleep 2
+    elapsed=$((elapsed + 2))
+  done
+  return 1
+}
+
+wait_for_postgres_ready() {
+  local timeout="${1:-60}"
+  local elapsed=0
+  while [[ $elapsed -lt $timeout ]]; do
+    if docker exec "$POSTGRES_CONTAINER" \
+        pg_isready -q -U "$KEYCLOAK_DB_USER" -d "$KEYCLOAK_DB_NAME" \
+        > /dev/null 2>&1; then
+      return 0
+    fi
+    sleep 2
+    elapsed=$((elapsed + 2))
+  done
+  return 1
+}
+
+# --- Test cases ---
+
+test_env_required() {
+  # Compose file uses ${VAR:?set in .env...} guards. Confirm `docker compose
+  # config` fails with a helpful message when .env is absent AND the shell
+  # has no matching vars exported. env -i wipes the inherited vars so the
+  # guards actually fire (otherwise our sourced .env leaks through).
+  if [[ ! -f .env ]]; then
+    fail ".env must exist before this test (was sourced above)"
+    return 1
+  fi
+  mv .env .env.bak
+  local out
+  out=$(env -i PATH="$PATH" HOME="$HOME" \
+    docker compose -f "$DOCKER_COMPOSE_FILE" config 2>&1 || true)
+  mv .env.bak .env
+  if echo "$out" | grep -qiE "set in \.env|required|is not set"; then
+    return 0
+  fi
+  fail "expected a required-variable error from docker compose config, got:"
+  echo "$out" >&2
+  return 1
+}
+
+test_backup_created() {
+  echo "  waiting up to 120s for first backup..."
+  if ! wait_for_first_backup 120; then
+    fail "no backup .gz file appeared within 120s"
+    return 1
+  fi
+  local first
+  first=$(list_backups | head -1)
+  if [[ -z "$first" ]]; then
+    fail "list_backups returned empty after wait"
+    return 1
+  fi
+  local size
+  size=$(backups_sh "stat -c %s $first" | tr -d '[:space:]')
+  if [[ -z "$size" || "$size" -le 0 ]]; then
+    fail "backup $first has size '$size' (expected > 0)"
+    return 1
+  fi
+  echo "  first backup: $first ($size bytes)"
+  return 0
+}
+
+test_backup_gunzip_ok() {
+  local first
+  first=$(list_backups | head -1)
+  if [[ -z "$first" ]]; then
+    fail "no backups available"
+    return 1
+  fi
+  if ! backups_sh "gunzip -t $first"; then
+    fail "gunzip -t failed on $first"
+    return 1
+  fi
+  return 0
+}
+
+test_backup_sql_valid() {
+  local first
+  first=$(list_backups | head -1)
+  if [[ -z "$first" ]]; then
+    fail "no backups available"
+    return 1
+  fi
+  local sample
+  sample=$(backups_sh "gunzip -c $first | head -50")
+  if ! echo "$sample" | grep -q "PostgreSQL database dump"; then
+    fail "expected 'PostgreSQL database dump' header in first 50 lines"
+    echo "--- got: ---" >&2
+    echo "$sample" >&2
+    return 1
+  fi
+  if ! echo "$sample" | grep -qE "CREATE (TABLE|SCHEMA)"; then
+    fail "expected CREATE TABLE or CREATE SCHEMA in first 50 lines"
+    echo "--- got: ---" >&2
+    echo "$sample" >&2
+    return 1
+  fi
+  return 0
+}
+
+test_backup_failure_detected() {
+  # Stop postgres so the next backup cycle cannot connect. The backup loop's
+  # `set -o pipefail` + failure branch should rename the partial to *.failed
+  # and emit a "Backup FAILED" log line. Restart postgres afterward so later
+  # tests have a live DB.
+  echo "  stopping postgres to force a backup-cycle failure"
+  docker stop "$POSTGRES_CONTAINER" > /dev/null
+
+  # INTERVAL=30s; wait one full cycle + buffer so at least one failed
+  # backup attempt completes.
+  echo "  waiting 45s for failed backup cycle..."
+  sleep 45
+
+  local failed_files
+  failed_files=$(backups_sh "ls ${BACKUPS_PATH}/*.failed 2>/dev/null" || true)
+
+  echo "  restarting postgres"
+  docker start "$POSTGRES_CONTAINER" > /dev/null
+  if ! wait_for_postgres_ready 60; then
+    fail "postgres did not become ready within 60s after restart"
+    return 1
+  fi
+
+  if [[ -z "$failed_files" ]]; then
+    fail "no *.failed file produced during postgres outage"
+    return 1
+  fi
+  if ! docker logs "$BACKUPS_CONTAINER" 2>&1 | grep -q "Backup FAILED"; then
+    fail "expected 'Backup FAILED' in backups container logs"
+    return 1
+  fi
+  echo "  observed failed file: $failed_files"
+  return 0
+}
+
+test_restore_roundtrip() {
+  # End-to-end proof that restore actually replaces DB state (not a no-op):
+  #   1. Snapshot the earliest backup (captured before any test mutations).
+  #   2. Insert a marker row; verify it is present in the live DB.
+  #   3. Drop + recreate + restore from the earliest backup directly via
+  #      docker exec (bypassing the interactive DESTROY prompt in
+  #      keycloak-restore-database.sh — the prompt is covered by PR #21's
+  #      safety guards, not by this test).
+  #   4. Verify marker is absent — restore truly replaced the DB state.
+  local baseline
+  baseline=$(list_backups | head -1)
+  if [[ -z "$baseline" ]]; then
+    fail "no baseline backup to restore"
+    return 1
+  fi
+  echo "  baseline backup: $baseline"
+
+  echo "  inserting marker row"
+  psql_query "CREATE TABLE IF NOT EXISTS restore_test (id int); INSERT INTO restore_test VALUES (1);" > /dev/null
+
+  local before_count
+  before_count=$(psql_query "SELECT count(*) FROM restore_test;" | tr -d '[:space:]')
+  if [[ "$before_count" != "1" ]]; then
+    fail "marker insert failed before restore: count=$before_count"
+    return 1
+  fi
+
+  echo "  restoring baseline (dropdb + createdb + gunzip | psql)"
+  if ! backups_sh "dropdb -h postgres -p 5432 -U $KEYCLOAK_DB_USER $KEYCLOAK_DB_NAME \
+      && createdb -h postgres -p 5432 -U $KEYCLOAK_DB_USER $KEYCLOAK_DB_NAME \
+      && gunzip -c $baseline | psql -h postgres -p 5432 -U $KEYCLOAK_DB_USER $KEYCLOAK_DB_NAME > /dev/null"; then
+    fail "restore commands failed"
+    return 1
+  fi
+
+  local after_regclass
+  after_regclass=$(psql_query "SELECT to_regclass('public.restore_test');" | tr -d '[:space:]')
+  # to_regclass returns empty string when the table does not exist.
+  if [[ -n "$after_regclass" && "$after_regclass" != "NULL" ]]; then
+    fail "restore_test table still exists after restore (to_regclass='$after_regclass') — restore was a no-op"
+    return 1
+  fi
+  echo "  marker absent after restore — backup is genuinely restorable"
+  return 0
+}
+
+test_prune_removes_old() {
+  local fake_old="${BACKUPS_PATH}/${BACKUP_PREFIX}-fake-0000-00-00_00-00.gz"
+  echo "  placing fake old file at $fake_old with mtime 14 days ago"
+  # postgres:16 is Debian-based; GNU touch -d handles relative date strings.
+  if ! backups_sh "echo fake > $fake_old && touch -d '14 days ago' $fake_old"; then
+    fail "could not create fake old file"
+    return 1
+  fi
+
+  # Prune runs once per backup cycle (INTERVAL=30s). Wait one full cycle
+  # plus a generous buffer to account for dump + gzip time on a warm DB.
+  echo "  waiting 45s for next prune cycle..."
+  sleep 45
+
+  if backups_sh "ls $fake_old 2>/dev/null" > /dev/null 2>&1; then
+    fail "fake old file still present after prune cycle"
+    return 1
+  fi
+
+  # Sanity check: recent backups must still be there (prune must not
+  # blanket-delete — see PR #21 prune-scope hardening).
+  if [[ -z "$(list_backups)" ]]; then
+    fail "prune removed everything, including recent backups"
+    return 1
+  fi
+  return 0
+}
+
+# --- Main ---
+
+echo "=== Keycloak backup/restore E2E tests ==="
+echo "  COMPOSE_PROJECT_NAME=${COMPOSE_PROJECT_NAME}"
+echo "  BACKUPS_CONTAINER=${BACKUPS_CONTAINER}"
+echo "  POSTGRES_CONTAINER=${POSTGRES_CONTAINER}"
+echo "  BACKUPS_PATH=${BACKUPS_PATH}"
+echo "  BACKUP_PREFIX=${BACKUP_PREFIX}"
+
+run_test test_env_required
+run_test test_backup_created
+run_test test_backup_gunzip_ok
+run_test test_backup_sql_valid
+run_test test_backup_failure_detected
+run_test test_restore_roundtrip
+run_test test_prune_removes_old
+
+echo
+echo "==============================="
+echo "Passed: $PASSED  Failed: $FAILED"
+if [[ ${#FAILURES[@]} -gt 0 ]]; then
+  echo "Failures:"
+  for f in "${FAILURES[@]}"; do
+    echo "  - $f"
+  done
+fi
+if [[ $FAILED -eq 0 ]]; then
+  exit 0
+fi
+exit 1


### PR DESCRIPTION
## Summary

Lands end-to-end CI tests that exercise every safety guard shipped in [PR #21](https://github.com/heyvaldemar/keycloak-traefik-letsencrypt-docker-compose/pull/21). A green CI run is now the authoritative proof that backup + restore work on every push — protection against unfounded "doesn't work for me" reports.

PR #21 promised this follow-up: _"A follow-up PR (#22) will add end-to-end CI smoke tests that exercise the new behaviour on every push."_ This is that PR.

## Latent bugs the new tests surfaced

The tests flushed out **two real bugs** that `deploy-and-test` (HTTPS-routing smoke only) never hit. Both are fixed in this PR — writing tests against broken behaviour would pin the bugs, so the sequence is fix-and-test-together.

| Bug | Reach | Surfaced by |
|---|---|---|
| Compose interpolated `$BACKUP_FILE` / `$SIZE` in the `backups` service command to empty strings (missing `$$` escapes introduced in PR #21) — every backup cycle wrote zero bytes to `""` and logged `sh: cannot create : Directory nonexistent`. | Any deployment (compose bug, always-on). | First local test run — `test_backup_created` found no `.gz` files. |
| Backup filenames used minute-granularity timestamps (`YYYY-MM-DD_HH-MM.gz`), so two cycles inside the same minute produced identical paths and the second overwrote the first. | Reachable when `KEYCLOAK_BACKUP_INTERVAL` is under 60s — unreachable at production default (24h). | First CI run with `INTERVAL=30s` — `test_backup_failure_detected`'s failure-cycle rename overwrote the good backup from 30s earlier, then `test_restore_roundtrip` failed with "no baseline backup to restore". |

## What changed per file

### `tests/e2e-backup-restore.sh` (new, 378 lines, shellcheck-clean)

Seven test cases, dispatched via a `run_test <name>` runner that tallies pass/fail. Every test emits a clear `ASSERT:` line on failure.

| Test | What it guards |
|---|---|
| `test_env_required` | Compose `${VAR:?set in .env...}` gate (PR #12) |
| `test_backup_created` | Backup loop produces a non-empty `.gz` within 120s |
| `test_backup_gunzip_ok` | Archive is a valid gzip stream (`gunzip -t`) |
| `test_backup_sql_valid` | Decompressed dump has `PostgreSQL database dump` + `CREATE TABLE`/`CREATE SCHEMA` |
| `test_backup_failure_detected` | `set -o pipefail` + `*.failed` rename + `Backup FAILED` log line (PR #21 failure-detection hardening) |
| `test_restore_roundtrip` | End-to-end proof restore is **not** a no-op: insert marker → restore earlier backup → marker absent |
| `test_prune_removes_old` | Scoped `find -mtime` prune deletes 14-day-old fake file; recent backups preserved (PR #21 prune-scope hardening) |

Setup creates a `backup_sql_valid_marker` CREATE TABLE before the first backup cycle fires, so every backup captured from test start onward has at least one CREATE TABLE statement — independent of Keycloak's own startup race (addresses a CI flake where Keycloak hadn't populated its public schema by the first backup at `INIT_SLEEP=10s`).

The restore roundtrip test bypasses the interactive `DESTROY` prompt in `keycloak-restore-database.sh` — the prompt is the *protection layer* covered by PR #21's safety guards, not the restore mechanics under test. The test replicates `dropdb && createdb && gunzip | psql` via `docker exec`, which is the same pipeline the safety-wrapped script eventually runs.

### `tests/README.md` (new)

Local-run instructions, the seven test cases enumerated, and required `.env` timing knobs (`INIT_SLEEP=10s`, `INTERVAL=30s`, `PRUNE_DAYS=7`). The production defaults (`30m` / `24h`) would time out the first-backup check.

### `.github/workflows/deployment-verification.yml`

- **New `backup-restore-e2e` job** (parallel to `deploy-and-test`, `needs: lint`, `timeout-minutes: 15`, `permissions: contents: read`).
  - Creates `keycloak-network` + `traefik-network`.
  - Generates an ephemeral `.env` with short backup intervals and placeholder hostnames — this job never exercises HTTPS, so real hostnames aren't needed.
  - `docker compose up -d`, polls `pg_isready` for postgres, then runs `./tests/e2e-backup-restore.sh`.
  - `if: failure()` shows container logs; `if: always()` runs `docker compose down`.
- **`lint` job's shellcheck** now covers `tests/*.sh` in addition to `./*.sh` — the test runner is linted alongside the restore script.

### `keycloak-traefik-letsencrypt-docker-compose.yml` — two fixes

**Fix 1: escape every container-shell variable with `$$`**. Latent bug from PR #21. Before: `$BACKUP_FILE` and `$SIZE` were local to the container shell but compose interpolated them to empty strings at config time. After: `$$BACKUP_FILE`, `$$SIZE`, `$$KEYCLOAK_*`, `$$(date ...)`. Block comment above the command documents the escape convention so future edits don't reintroduce the bug.

**Fix 2: timestamp format `YYYY-MM-DD_HH-MM-SS.gz`**. Was `YYYY-MM-DD_HH-MM.gz`. Prevents filename collisions at sub-minute intervals. Backward-compatible — prune glob and restore script's filename listing both match both formats.

### `keycloak-restore-database.sh` — one-line edit

Updates the example filename in the "Copy and paste" prompt from `...hh-mm.gz` to `...hh-mm-ss.gz` to match the new format.

### `README.md`

- Contents TOC gains a `Testing` entry between Restoring and Security Notes.
- New `## Testing` section describes the seven test cases and the CI job.
- Comparison-table row "CI-verified deployment on every push" → "CI-verified deployment + backup/restore on every push".
- Backups-section expected-log-output example timestamps updated to include seconds.

### `CHANGELOG.md`

- `[Unreleased] → Fixed` entries for the compose interpolation and timestamp collision bugs.
- `[Unreleased] → Added` for the test suite, CI job, shellcheck scope extension, tests/README.md, README Testing section.

## Design decisions worth calling out

**Why parallel to `deploy-and-test`, not a dependency?** Backup/restore is orthogonal to HTTPS routing. One failing shouldn't mask the other. Both fan out from `needs: lint` so the compose-up slot isn't burned on workflow-syntax errors.

**Why not call `keycloak-restore-database.sh` directly in the restore test?** The script has an interactive `DESTROY` prompt — that prompt is PR #21's safety guard, not the mechanics being tested. A `printf DESTROY\\n | ...` test would couple to the prompt's exact wording and break the moment PR #21's UX changes. The e2e test validates the underlying `dropdb && createdb && gunzip | psql` pipeline, which is invariant.

**Why fix both latent bugs in this PR rather than separate hotfixes?** They're only reachable when someone actually *uses* the backup loop — and the tests are the first thing that does. Landing tests against the broken code would result in red PRs and require chained hotfixes; fixing here keeps the "test-surfaces-bug, fix-in-same-PR" story coherent.

**Why 45-second waits in failure + prune tests?** `INTERVAL=30s` means one full cycle, and a backup cycle is "start → pg_dump → gzip → prune → sleep 30". Worst-case timing from "put fake file in place" to "prune cycle runs" is ~34s on a cold DB. 45s gives headroom for GitHub Actions runner variance.

## Verification

- [x] `shellcheck ./*.sh tests/*.sh` — clean (0 findings)
- [x] `actionlint` on updated workflow — clean
- [x] **Full local run**: 7/7 pass in ~4 min wall-clock
- [x] **CI run** (commit `71f7527`): `backup-restore-e2e` passes in 2m12s, every other check green — [actions/runs/24872771374](https://github.com/heyvaldemar/keycloak-traefik-letsencrypt-docker-compose/actions/runs/24872771374)

## Test plan (post-merge)

- [ ] First post-merge CI run on main: `backup-restore-e2e` passes in under 15 min wall-clock.
- [ ] Weekly Monday run: passes, confirming the tests aren't flaky against runner variance.
- [ ] Next Dependabot postgres digest bump: `backup-restore-e2e` validates the new digest still supports `pg_dump | gzip` + `gunzip -t` + `dropdb && createdb && psql`.

## Diff stats

```
 .github/workflows/deployment-verification.yml   |  92 +++++-
 CHANGELOG.md                                    |  55 +++
 README.md                                       |  27 +-
 keycloak-restore-database.sh                    |   2 +-
 keycloak-traefik-letsencrypt-docker-compose.yml |  30 +-
 tests/README.md                                 |  65 +++
 tests/e2e-backup-restore.sh                     | 378 ++++++++++++++++++++++++
 7 files changed, 631 insertions(+), 18 deletions(-)
```

## Follow-up

After this merges, a tiny PR on [`heyvaldemar-com`](https://github.com/heyvaldemar/heyvaldemar-com) adds a "Tested on every push" tip callout to the [Install Keycloak Using Docker Compose](https://heyvaldemar.com/install-keycloak-using-docker-compose/) blog article, linking readers to the green CI run as deploy-template evidence.

🤖 Generated with [Claude Code](https://claude.com/claude-code)