### PR TITLE
fix(tests): dropdb --force in test_restore_roundtrip to handle live Keycloak pool

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,21 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Fixed
+- **`test_restore_roundtrip` race against the Keycloak DB pool.** The test
+  ran `dropdb` directly against `keycloakdb` while the live Keycloak
+  service still held connections through its JDBC pool. On runners where
+  Keycloak's startup happened to land before the test reached the drop,
+  Postgres rejected the operation with `database "keycloakdb" is being
+  accessed by other users`. Passed intermittently in earlier CI runs
+  because Keycloak's connection-pool establishment timing varied; surfaced
+  as a hard failure on the 2026-05-04 weekly cron. Fix: pass `--force` to
+  `dropdb` (Postgres 13+; available in `postgres:16`), which terminates
+  active backends before dropping the database. The production restore
+  script (`keycloak-restore-database.sh`) sidesteps the race by stopping
+  Keycloak first; this test exercises the underlying primitives directly,
+  so `--force` is the appropriate equivalent. No change to the test's
+  semantic — the assertion that the marker row is absent after restore is
+  unchanged.
 - **Backup filename collision at sub-minute intervals.** Backup filenames
   use only minute granularity
   (`keycloak-postgres-backup-YYYY-MM-DD_HH-MM.gz`), so two cycles inside

--- a/tests/e2e-backup-restore.sh
+++ b/tests/e2e-backup-restore.sh
@@ -295,8 +295,15 @@ test_restore_roundtrip() {
     return 1
   fi
 
-  echo "  restoring baseline (dropdb + createdb + gunzip | psql)"
-  if ! backups_sh "dropdb -h postgres -p 5432 -U $KEYCLOAK_DB_USER $KEYCLOAK_DB_NAME \
+  echo "  restoring baseline (dropdb --force + createdb + gunzip | psql)"
+  # `--force` is required (Postgres 13+; available in postgres:16) because
+  # Keycloak keeps an active connection to keycloakdb via its JDBC pool.
+  # Without it, dropdb fails with "database ... is being accessed by other
+  # users". The production restore script (keycloak-restore-database.sh)
+  # avoids the race by stopping Keycloak first; this test exercises the
+  # underlying primitives directly and uses --force to terminate live
+  # backends instead.
+  if ! backups_sh "dropdb --force -h postgres -p 5432 -U $KEYCLOAK_DB_USER $KEYCLOAK_DB_NAME \
       && createdb -h postgres -p 5432 -U $KEYCLOAK_DB_USER $KEYCLOAK_DB_NAME \
       && gunzip -c $baseline | psql -h postgres -p 5432 -U $KEYCLOAK_DB_USER $KEYCLOAK_DB_NAME > /dev/null"; then
     fail "restore commands failed"


### PR DESCRIPTION
## What broke

The 2026-05-04 weekly cron run [25305291519](https://github.com/heyvaldemar/keycloak-traefik-letsencrypt-docker-compose/actions/runs/25305291519) failed in the \`backup-restore-e2e\` job at \`test_restore_roundtrip\`:

\`\`\`
=== test_restore_roundtrip ===
  baseline backup: /srv/keycloak-postgres/backups/keycloak-postgres-backup-2026-05-04_06-53-58.gz
  inserting marker row
  restoring baseline (dropdb + createdb + gunzip | psql)
dropdb: error: database removal failed: ERROR:  database "keycloakdb" is being accessed by other users
DETAIL:  There is 1 other session using the database.
  ASSERT: restore commands failed
  FAIL: test_restore_roundtrip
\`\`\`

6 of 7 tests passed; only \`test_restore_roundtrip\` failed.

## Root cause

The test calls \`dropdb keycloakdb\` directly while the live Keycloak service still holds a JDBC-pool connection to the database. Postgres correctly refuses to drop a DB that has active backends.

This worked intermittently on previous runs because Keycloak's startup → pool establishment timing is variable across runners. It just happened to land on the wrong side of the race on 2026-05-04.

The production restore script (\`keycloak-restore-database.sh\`) avoids the race by \`docker compose stop keycloak\` before dropdb. The test exercises the underlying primitives directly (by design — the test isolates the dropdb / createdb / restore mechanism from the keycloak-stop wrapper), so it needs the equivalent at the SQL primitive level.

## Fix

Pass \`--force\` to \`dropdb\`:

\`\`\`diff
-  if ! backups_sh \"dropdb -h postgres -p 5432 -U \$KEYCLOAK_DB_USER \$KEYCLOAK_DB_NAME \\\\
+  if ! backups_sh \"dropdb --force -h postgres -p 5432 -U \$KEYCLOAK_DB_USER \$KEYCLOAK_DB_NAME \\\\
\`\`\`

\`dropdb --force\` (Postgres 13+) terminates active backends before dropping the database. Confirmed available on the pinned \`postgres:16\` image:

\`\`\`
\$ docker run --rm postgres:16@sha256:71e27bf6... dropdb --help | grep force
  -f, --force               try to terminate other connections before dropping
\`\`\`

Plus a comment block above the line explaining why \`--force\` is required and how the production restore path differs (stops Keycloak first instead).

## Test plan

- [x] \`bash -n tests/e2e-backup-restore.sh\` — script parses cleanly
- [x] \`shellcheck ./*.sh tests/*.sh\` — exit 0, matches the \`lint\` job in CI
- [x] \`dropdb --help\` confirms \`--force\` is supported on the pinned postgres:16
- [ ] \`backup-restore-e2e\` job goes green on this PR — should now reliably pass test_restore_roundtrip regardless of Keycloak-pool timing

## No semantic change

The assertion that the marker row is absent after restore is unchanged. Only the dropdb invocation is modified to handle the live-pool case.