### PR TITLE
docs(readme): add Prerequisites + What-success-looks-like + Common issues

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,6 +7,7 @@
 ## Contents
 
 - [Why this stack?](#why-this-stack)
+- [Prerequisites](#prerequisites)
 - [Getting started](#getting-started)
 - [Features](#features)
   - [Typical use cases](#typical-use-cases)
@@ -41,6 +42,18 @@ This repository deploys **Keycloak** behind **Traefik** with automatic **Let's E
 
 Four moving parts (Traefik + Keycloak + Postgres + backups). No hidden complexity, no Kubernetes prerequisites, no manual certificate management.
 
+## Prerequisites
+
+Before you start, you need:
+
+- **A Linux server** with a public IP. Tested on Ubuntu 22.04 LTS+ and Debian 12+; should work on any distro that runs current Docker. Local Mac/Windows works for dev; production is Linux.
+- **Docker Engine 24+ and Docker Compose 2.20+.** Quick check: `docker version` and `docker compose version`. If you don't have Docker yet: [official install guide](https://docs.docker.com/engine/install/).
+- **A domain you control,** with two `A` records (or `CNAME`s) pointing at your server's public IP — one for Keycloak (e.g. `keycloak.example.com`), one for the Traefik dashboard (e.g. `traefik.keycloak.example.com`). DNS must propagate before deploy or Let's Encrypt's TLS-ALPN challenge will fail.
+- **Ports 80 and 443 open** on the server's firewall and not bound by another service. Quick check: `sudo ss -ltn '( sport = :80 or sport = :443 )'` should be empty.
+- **~2 GB free RAM and 1 free CPU** for the running stack. ~500 MB of disk for the images plus whatever your backup retention requires.
+
+That's it. No Kubernetes, no separate database server, no certbot setup.
+
 ## Getting started
 
 ```bash
@@ -65,7 +78,34 @@ docker compose -f keycloak-traefik-letsencrypt-docker-compose.yml -p keycloak up
 
 Within a minute or two, both `https://${KEYCLOAK_HOSTNAME}` (Keycloak UI) and `https://${TRAEFIK_HOSTNAME}` (Traefik dashboard, basic-auth protected) are live with fresh Let's Encrypt certificates.
 
-Apply `.env` or compose-file changes:
+### What success looks like
+
+```bash
+# All four services should report as healthy:
+docker compose -f keycloak-traefik-letsencrypt-docker-compose.yml -p keycloak ps
+# Expected: postgres, keycloak, traefik all show "(healthy)"; backups shows "Up"
+
+# Traefik should have issued a Let's Encrypt cert within ~30s of first start:
+docker compose -p keycloak logs traefik | grep -i "adding certificate"
+# Expected: "Adding certificate for domain(s) keycloak.example.com"
+
+# Keycloak responds on its public URL:
+curl -fsS -o /dev/null -w "%{http_code}\n" "https://${KEYCLOAK_HOSTNAME}/health/ready"
+# Expected: 200
+
+# First backup lands in the volume after KEYCLOAK_BACKUP_INIT_SLEEP (default 30m):
+docker compose -p keycloak logs backups | tail -3
+# Expected: a "Backup OK: ... (NN bytes)" line
+```
+
+### Common first-deploy issues
+
+- **Cert issuance fails / no `adding certificate` log line.** Either DNS hasn't propagated to your server's IP yet, or port 80 isn't reachable from the public internet. Confirm with `dig +short ${KEYCLOAK_HOSTNAME}` (should match server IP) and `curl -I http://${KEYCLOAK_HOSTNAME}` from outside the server (should not time out).
+- **`docker compose up` fails with `set in .env`.** A required variable is empty in `.env`. The error message lists the variable. Most likely candidates: `KEYCLOAK_DB_PASSWORD`, `KEYCLOAK_ADMIN_PASSWORD`, `TRAEFIK_BASIC_AUTH`. Generate per the comments in `.env.example`.
+- **`network keycloak-network not found`.** Step 2 (the `docker network create ...` commands) was skipped. Run them and retry.
+- **Keycloak container restarts in a loop with `Build failed due to errors`.** This is rare and means an env var combo isn't supported by the upstream image's auto-build. Check `docker compose -p keycloak logs keycloak` for the specific error and reach out via [Issues](https://github.com/heyvaldemar/keycloak-traefik-letsencrypt-docker-compose/issues).
+
+### Apply `.env` or compose-file changes
 
 ```bash
 docker compose -f keycloak-traefik-letsencrypt-docker-compose.yml -p keycloak up -d --force-recreate


### PR DESCRIPTION
## Why

\"Apple-style\" polish for the deploy path. The repo is dual-purpose: portfolio + production-deployable template. A junior who finds it via Docker Hub or a blog post should be able to deploy it in 5-10 minutes from the top of the README — without having to read the whole thing or hunt around for prereqs / verification / troubleshooting.

## Three additions

### 1. Prerequisites (above Getting started)

Concrete checklist with one-line verification per item:
- Linux server (tested distros)
- Docker Engine 24+ and Docker Compose 2.20+ (\`docker version\`, \`docker compose version\`)
- Domain with DNS A records pointing at the server
- Ports 80/443 free (\`sudo ss -ltn '(sport = :80 or sport = :443)'\`)
- Resource ceiling guidance (~2 GB RAM, 1 CPU, ~500 MB disk)

### 2. What success looks like (after the deploy command)

Four self-contained verification one-liners with expected output:
- \`docker compose ps\` → all services \"(healthy)\"
- \`docker compose logs traefik | grep adding certificate\` → cert issuance log line
- \`curl /health/ready\` → 200
- \`docker compose logs backups\` → \"Backup OK\" line after INIT_SLEEP elapses

### 3. Common first-deploy issues (inline at end of Getting started)

Four most-frequent failure modes with the diagnostic command:
- Cert issuance fails (DNS / port 80)
- Required var missing (which vars to fill)
- Network-not-found (skipped step 2)
- Keycloak build loop (rare, links to Issues)

Inline so the reader doesn't have to know there's a separate Troubleshooting section.

## What this is NOT

- Not a content rewrite. Existing sections (Why this stack, Features, Supply chain, Production checklist, Backups, Restoring, Testing, Security Notes, Container hardening, Standardization reference) are untouched.
- Not an evaluator-experience change. The comparison table and supply-chain section still land for evaluators reading top-to-bottom.

## Test plan

- [x] CI lint job (validates README has no shellcheck-able syntax issues in fenced bash blocks — implicit since the lint job runs shellcheck on \`./*.sh\` and \`tests/*.sh\`)
- [x] CI deploy-and-test job (no compose / .env changes; should pass identically)
- [x] CI backup-restore-e2e job (no test or compose changes)
- [ ] README renders cleanly on GitHub (anchor links work, code blocks formatted)